### PR TITLE
Fixed isort deprecation warnings and fix-lint error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-all: ## run tests on every Python version with tox
 fix-lint: ## fix lint issues using autoflake, autopep8, and isort
 	find pyreal tests -name '*.py' | xargs autoflake --in-place --remove-all-unused-imports --remove-unused-variables
 	autopep8 --in-place --recursive --aggressive pyreal tests
-	isort --apply --atomic --recursive pyreal tests
+	isort --atomic pyreal tests --skip __init__.py
 
 .PHONY: coverage
 coverage: ## check code coverage quickly with the default Python

--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -60,6 +60,7 @@ class Explainer(ABC):
            If True, do not run the transform_explanation methods from i_transforms
            on the explanation after producing.
     """
+
     def __init__(self, algorithm, model,
                  x_orig, y_orig=None,
                  feature_descriptions=None,
@@ -113,7 +114,6 @@ class Explainer(ABC):
         """
         Fit this explainer object. Abstract method
         """
-        pass
 
     @abstractmethod
     def produce(self, x_orig):
@@ -128,7 +128,6 @@ class Explainer(ABC):
             Type varies by subclass
                 Explanation
         """
-        pass
 
     def transform_to_x_explain(self, x_orig):
         """

--- a/pyreal/explainers/lfc/base.py
+++ b/pyreal/explainers/lfc/base.py
@@ -26,6 +26,7 @@ class LocalFeatureContributionsBase(Explainer, ABC):
             default names
         **kwargs: see base Explainer args
     """
+
     def __init__(self, algorithm, model, x_orig, interpretable_features=True, **kwargs):
         self.interpretable_features = interpretable_features
         super(LocalFeatureContributionsBase, self).__init__(algorithm, model, x_orig, **kwargs)
@@ -35,7 +36,6 @@ class LocalFeatureContributionsBase(Explainer, ABC):
         """
         Fit this explainer object
         """
-        pass
 
     def produce(self, x_orig):
         """
@@ -69,4 +69,3 @@ class LocalFeatureContributionsBase(Explainer, ABC):
             DataFrame of shape (n_instances, n_features)
                 Contribution of each feature for each instance
         """
-        pass

--- a/pyreal/explainers/lfc/shap_feature_contribution.py
+++ b/pyreal/explainers/lfc/shap_feature_contribution.py
@@ -22,12 +22,13 @@ class ShapFeatureContribution(LocalFeatureContributionsBase):
             Type of shap algorithm to use. If None, SHAP will pick one.
         **kwargs: see base Explainer args
     """
+
     def __init__(self, model, x_orig,
                  shap_type=None, **kwargs):
         supported_types = ["kernel", "linear"]
         if shap_type is not None and shap_type not in supported_types:
             raise ValueError("Shap type not supported, given %s, expected one of %s or None" %
-                  (shap_type, str(supported_types)))
+                             (shap_type, str(supported_types)))
         else:
             self.shap_type = shap_type
 

--- a/pyreal/utils/transformer.py
+++ b/pyreal/utils/transformer.py
@@ -74,6 +74,7 @@ class MappingsEncoderTransformer(BaseTransformer):
     """
     Converts data from categorical form to one-hot-encoded
     """
+
     def __init__(self, mappings):
         self.mappings = mappings
 
@@ -94,6 +95,7 @@ class MappingsDecoderTransformer(BaseTransformer):
     """
     Converts data from one-hot encoded form to categorical
     """
+
     def __init__(self, mappings):
         self.mappings = mappings
 
@@ -162,6 +164,7 @@ class DataFrameWrapper(BaseTransformer):
     """
     Allows use of standard sklearn transformers while maintaining DataFrame type.
     """
+
     def __init__(self, base_transformer):
         self.base_transformer = base_transformer
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ include_trailing_comma = True
 line_length=99
 lines_between_types = 0
 multi_line_output = 4
-not_skip = __init__.py
 use_parentheses = True
 
 [aliases]


### PR DESCRIPTION
Address #27 
1. Removed deprecated isort command arguments
2. `make fix-lint` now ignores `__init__` files, to prevent it from breaking import order
3. Small linting fixes