### PR TITLE
Updating python version support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ data form.
 
 ## Requirements
 
-**Pyreal** has been developed and tested on [Python 3.7, 3.8, and 3.9](https://www.python.org/downloads/)
+**Pyreal** has been developed and tested on [Python 3.7 and 3.8](https://www.python.org/downloads/)
 
 Also, although it is not strictly required, the usage of a [virtualenv](https://virtualenv.pypa.io/en/latest/)
 is highly recommended in order to avoid interfering with other software installed in the system

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
     ],
     description='Library for evaluating and deploying machine learning explanations.',
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py37, py38, py39, lint, docs
+envlist = py37, py38, lint, docs
 
 
 [travis]
 python =
-    3.9: py39
     3.8: py38
     3.7: py37, docs, lint
 


### PR DESCRIPTION
This is currently a draft PR to address python support issues. 

It has the following changes:
1. It officially removes support for `python 3.4` and `python 3.5` (which are already past end of life), as well as `python 3.6`, which will reach end of life by the end of this year.
3. ~~It adds official support for `python 3.9`.~~ `python 3.9` is not yet officially supported by Tensorflow, so we will hold off on this support for now.
5. All supported python versions will now be tested in the CI process.

This PR fixes #39.
