### PR TITLE
Fixing links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 Library for evaluating and deploying machine learning explanations.
 
 - Free software: Not open source
-- Documentation: https://DAI-Lab.github.io/pyreal
-- Homepage: https://github.com/DAI-Lab/pyreal
+- Documentation: https://sibyl-dev.github.io/pyreal
+- Homepage: https://github.com/sibyl-dev/pyreal
 
 # Overview
 


### PR DESCRIPTION
Tiny PR fixing links in README to point to the right place following the organization switch. Closes #57.