### PR TITLE
Adding fit_transform to BaseTransformer

### DIFF
--- a/pyreal/utils/transformer.py
+++ b/pyreal/utils/transformer.py
@@ -56,11 +56,15 @@ def run_transformers(transformers, x_orig):
 
 class BaseTransformer(ABC):
     @abstractmethod
-    def transform(self, data):
+    def transform(self, x):
         pass
 
-    def fit(self, *args, **kwargs):
+    def fit(self, x, **params):
         pass
+
+    def fit_transform(self, x, **fit_params):
+        self.fit(x, **fit_params)
+        return self.transform(x)
 
     def transform_explanation(self, explanation, algorithm):
         if algorithm == ExplanationAlgorithm.SHAP:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_require = [
     'jupyter>=1.0.0,<2',
     'rundoc>=0.4.3,<0.5',
     'invoke',
-    'nbmake==0.7.',
+    'nbmake==0.7.0',
 ]
 
 development_requires = [


### PR DESCRIPTION
Adding a `fit_transform` function to `BaseTransformer` that simply runs fit and then transform on data. This allows `pyreal` transformers to be substituted for `sklearn` transformers.

Closes #48.