### PR TITLE
Removed MacOS Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
 
     steps:


### PR DESCRIPTION
Removes MacOS from the testing matrix because it costs 10x minutes to operate and is similar enough to the ubuntu-latest image in environment where it is not needed.