### PR TITLE
Fixing README issues with branch names and venv references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The library uses Poetry for package management.
 
 ## Install from PyPI
 
-After creating the virtualenv and activating it, we recommend using
+We recommend using
 [pip](https://pip.pypa.io/en/stable/) in order to install **Pyreal**:
 
 ```
@@ -44,12 +44,11 @@ This will pull and install the latest stable release from [PyPI](https://pypi.or
 ## Install from source
 
 You can clone the repository and install it from
-source by running `poetry install` on the `stable` branch:
+source by running `poetry install`:
 
 ```
 git clone git@github.com:DAI-Lab/pyreal.git
 cd pyreal
-git checkout stable
 poetry install
 ```
 


### PR DESCRIPTION
Addresses and closes #72.

1. With our branch structure, our stable branch is our master branch (with `dev` holding the most recent development version). This PR removes the reference to the stable branch. No branch change is necessary to get the stable version on `Pyreal`. The contributing guide includes details on getting the development version (`dev`).
2. The incorrect reference to python 3.6 has since been removed in PR #43. This PR includes a minor fix to the wording that removed references to virtualenv, which users may or may not be using for their own projects (Pyreal itself uses Poetry and does not require a virtualenv).

