### PR TITLE
Fixing library name in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* Explanation Toolkit version:
+* Pyreal version:
 * Python version:
 * Operating System:
 


### PR DESCRIPTION
This is a tiny PR that updates the name used in the github issue template from Explanation Toolkit to Pyreal

Closes #117 