### PR TITLE
Updating branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <!-- Uncomment these lines after releasing the package to PyPI for version and downloads badges -->
 [![PyPI Shield](https://img.shields.io/pypi/v/pyreal.svg)](https://pypi.python.org/pypi/pyreal)
 <!--[![Downloads](https://pepy.tech/badge/pyreal)](https://pepy.tech/project/pyreal)-->
-<!--[![Travis CI Shield](https://travis-ci.org/DAI-Lab/pyreal.svg?branch=master)](https://travis-ci.org/DAI-Lab/pyreal)-->
-<!--[![Coverage Status](https://codecov.io/gh/DAI-Lab/pyreal/branch/master/graph/badge.svg)](https://codecov.io/gh/DAI-Lab/pyreal)-->
+<!--[![Travis CI Shield](https://travis-ci.org/DAI-Lab/pyreal.svg?branch=stable)](https://travis-ci.org/DAI-Lab/pyreal)-->
+<!--[![Coverage Status](https://codecov.io/gh/DAI-Lab/pyreal/branch/stable/graph/badge.svg)](https://codecov.io/gh/DAI-Lab/pyreal)-->
 [![Build Action Status](https://github.com/DAI-Lab/pyreal/workflows/Test%20CI/badge.svg)](https://github.com/DAI-Lab/pyreal/actions)
 # Pyreal
 

--- a/docs/developer_guides/contributing.rst
+++ b/docs/developer_guides/contributing.rst
@@ -255,8 +255,8 @@ The process of releasing a new version involves several steps::
    ``pyproject.toml`` files.
 3. Make any final small changes needed, either directly on ``release-v.*.*.*`` or on a
    feature branch that can then be merged into ``release-v.*.*.*`` with a PR.
-4. Make a PR to merge ``release-v.*.*.*`` into ``master``
-5. Once merged, tag the merge commit in master, and push the tag.
+4. Make a PR to merge ``release-v.*.*.*`` into ``stable``
+5. Once merged, tag the merge commit in stable, and push the tag.
    This will automatically deploy the release to pypi.
 6. Merge ``release-v.*.*.*`` back into ``dev`` with a pull request
 7. Make a release on github.com, filling in the release notes with


### PR DESCRIPTION
### Closing issues

Closes #129 

### Description

This branch updated documentation to use the term `stable` instead of `master`, for clarity and accuracy

### Test Plan

Running the doc build works and generates correct docs
