### PR TITLE
remove e_algorithm traces in base file

### DIFF
--- a/pyreal/explainers/dte/base.py
+++ b/pyreal/explainers/dte/base.py
@@ -17,9 +17,6 @@ class DecisionTreeExplainerBase(Explainer, ABC):
            Filepath to the pickled model to explain, or model object with .predict() function
         x_train_orig (dataframe of shape (n_instances, x_orig_feature_count)):
            The training set for the explainer
-        e_algorithm (string, one of ["surrogate_tree"]):
-           Explanation algorithm to use. If none, one will be chosen automatically based on model
-           type
         interpretable_features (Boolean):
             If True, return explanations using the interpretable feature descriptions instead of
             default names

--- a/pyreal/explainers/dte/base.py
+++ b/pyreal/explainers/dte/base.py
@@ -11,8 +11,6 @@ class DecisionTreeExplainerBase(Explainer, ABC):
     decision trees and 2) visualizing the decision rules associated with a prediction.
 
     Args:
-        algorithm (ExplanationAlgorithm or None):
-            Name of the algorithm this Explainer uses
         model (string filepath or model object):
            Filepath to the pickled model to explain, or model object with .predict() function
         x_train_orig (dataframe of shape (n_instances, x_orig_feature_count)):

--- a/pyreal/explainers/dte/decision_tree_explainer.py
+++ b/pyreal/explainers/dte/decision_tree_explainer.py
@@ -39,7 +39,7 @@ def dte(return_explainer=True, return_importances=False, explainer=None,
             If true, fit a decision tree classifier; otherwise fit a decision tree regressor.
         max_depth (Integer):
             If given, this sets the maximum depth of the decision tree produced by the explainer.
-        e_algorithm (string, one of ["shap"]):
+        e_algorithm (string, one of ["surrogate_tree"]):
            Explanation algorithm to use. If none, one will be chosen automatically based on model
            type
         feature_descriptions (dict):

--- a/pyreal/explainers/gfi/base.py
+++ b/pyreal/explainers/gfi/base.py
@@ -18,9 +18,6 @@ class GlobalFeatureImportanceBase(Explainer, ABC):
            Filepath to the pickled model to explain, or model object with .predict() function
         x_train_orig (dataframe of shape (n_instances, x_orig_feature_count)):
            The training set for the explainer
-        e_algorithm (string, one of ["shap"]):
-           Explanation algorithm to use. If none, one will be chosen automatically based on model
-           type
         interpretable_features (Boolean):
             If True, return explanations using the interpretable feature descriptions instead of
             default names

--- a/pyreal/explainers/lfc/base.py
+++ b/pyreal/explainers/lfc/base.py
@@ -18,9 +18,6 @@ class LocalFeatureContributionsBase(Explainer, ABC):
            Filepath to the pickled model to explain, or model object with .predict() function
         x_train_orig (dataframe of shape (n_instances, x_orig_feature_count)):
            The training set for the explainer
-        e_algorithm (string, one of ["shap"]):
-           Explanation algorithm to use. If none, one will be chosen automatically based on model
-           type
         interpretable_features (Boolean):
             If True, return explanations using the interpretable feature descriptions instead of
             default names


### PR DESCRIPTION
Removing outdated `e_algorithm` arguments in the explainer base class descriptions.
