### PR TITLE
Adding return self to fit functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ passenger on the Titanic would have survived.
 ...                                transformers=transformers,
 ...                                feature_descriptions=feature_descriptions,
 ...                                fit_on_init=True)
->>> lfc.fit()
 
 # Make predictions on an input
 >>> input_to_explain = x_train_orig.iloc[0]

--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -140,6 +140,7 @@ class Explainer(ABC):
         """
         Fit this explainer object. Abstract method
         """
+        return self
 
     @abstractmethod
     def produce(self, x_orig):

--- a/pyreal/explainers/dte/decision_tree_explainer.py
+++ b/pyreal/explainers/dte/decision_tree_explainer.py
@@ -127,6 +127,7 @@ class DecisionTreeExplainer(DecisionTreeExplainerBase):
         Fit this explainer object
         """
         self.base_decision_tree.fit()
+        return self
 
     def produce(self, x_orig=None):
         """

--- a/pyreal/explainers/dte/surrogate_decision_tree.py
+++ b/pyreal/explainers/dte/surrogate_decision_tree.py
@@ -44,6 +44,7 @@ class SurrogateDecisionTree(DecisionTreeExplainerBase):
         else:
             self.explainer = tree.DecisionTreeRegressor(max_depth=self.max_depth)
             self.explainer.fit(e_dataset, self.model.predict(m_dataset))
+        return self
 
     def produce(self):
         """

--- a/pyreal/explainers/gfi/global_feature_importance.py
+++ b/pyreal/explainers/gfi/global_feature_importance.py
@@ -123,6 +123,7 @@ class GlobalFeatureImportance(GlobalFeatureImportanceBase):
         Fit this explainer object
         """
         self.base_global_feature_importance.fit()
+        return self
 
     def get_importance(self):
         """

--- a/pyreal/explainers/gfi/permutation_feature_importance.py
+++ b/pyreal/explainers/gfi/permutation_feature_importance.py
@@ -31,6 +31,7 @@ class PermutationFeatureImportance(GlobalFeatureImportanceBase):
         Fit the feature importance explainer.
         No-op as permutation_importance does not require fitting
         """
+        return self
 
     def get_importance(self):
         """

--- a/pyreal/explainers/gfi/shap_feature_importance.py
+++ b/pyreal/explainers/gfi/shap_feature_importance.py
@@ -49,6 +49,7 @@ class ShapFeatureImportance(GlobalFeatureImportanceBase):
             self.explainer = LinearExplainer(self.model, dataset)
         else:
             self.explainer = ShapExplainer(self.model, dataset)  # SHAP will pick an algorithm
+        return self
 
     def get_importance(self):
         """

--- a/pyreal/explainers/lfc/local_feature_contribution.py
+++ b/pyreal/explainers/lfc/local_feature_contribution.py
@@ -126,6 +126,7 @@ class LocalFeatureContribution(LocalFeatureContributionsBase):
         Fit this explainer object
         """
         self.base_local_feature_contribution.fit()
+        return self
 
     def get_contributions(self, x_orig):
         """

--- a/pyreal/explainers/lfc/shap_feature_contribution.py
+++ b/pyreal/explainers/lfc/shap_feature_contribution.py
@@ -51,6 +51,7 @@ class ShapFeatureContribution(LocalFeatureContributionsBase):
             self.explainer = LinearExplainer(self.model, dataset)
         else:
             self.explainer = ShapExplainer(self.model, dataset)  # SHAP will pick an algorithm
+        return self
 
     def get_contributions(self, x_orig):
         """

--- a/pyreal/explainers/lfc/simple_counterfactual_contribution.py
+++ b/pyreal/explainers/lfc/simple_counterfactual_contribution.py
@@ -39,6 +39,7 @@ class SimpleCounterfactualContribution(LocalFeatureContributionsBase):
         """
         dataset = self.transform_to_x_explain(self.x_train_orig)
         self.explainer_input_size = dataset.shape[1]
+        return self
 
     def get_contributions(self, x_orig):
         """

--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -69,6 +69,7 @@ class Transformer(ABC):
         Returns:
             None
         """
+        return self
 
     @abstractmethod
     def data_transform(self, x):

--- a/pyreal/transformers/feature_select.py
+++ b/pyreal/transformers/feature_select.py
@@ -31,6 +31,7 @@ class FeatureSelectTransformer(Transformer):
 
         """
         self.dropped_columns = list(set(x.columns) - set(self.columns))
+        return self
 
     def data_transform(self, x):
         """

--- a/pyreal/transformers/impute.py
+++ b/pyreal/transformers/impute.py
@@ -41,6 +41,7 @@ class MultiTypeImputer(Transformer):
             self.numeric_imputer.fit(x[self.numeric_cols])
         if len(self.categorical_cols) > 0:
             self.categorical_imputer.fit(x[self.categorical_cols])
+        return self
 
     def data_transform(self, x):
         """

--- a/pyreal/transformers/one_hot_encode.py
+++ b/pyreal/transformers/one_hot_encode.py
@@ -123,6 +123,7 @@ class OneHotEncoder(Transformer):
             self.columns = x.columns
         self.ohe.fit(x[self.columns])
         self.is_fit = True
+        return self
 
     def data_transform(self, x):
         """

--- a/pyreal/transformers/wrappers.py
+++ b/pyreal/transformers/wrappers.py
@@ -31,6 +31,7 @@ class DataFrameWrapper(Transformer):
             None
         """
         self.wrapped_transformer.fit(x)
+        return self
 
     def data_transform(self, x):
         """


### PR DESCRIPTION
### Closing issues

Closes #86 

### Description

This small PR adds a `return self` to all Explainer and Transformer fit functions, improving consistency with other libraries such as sklearn and allowing lines of code like: `oneHotEncoder.fit().transform()

### Test Plan

All existing tests continue to pass
