### PR TITLE
Transformers now accept scalars as columns

### DIFF
--- a/pyreal/transformers/feature_select.py
+++ b/pyreal/transformers/feature_select.py
@@ -1,3 +1,8 @@
+import collections
+
+import numpy as np
+import pandas as pd
+
 from pyreal.transformers import Transformer
 from pyreal.types.explanations.dataframe import (
     AdditiveFeatureContributionExplanation, FeatureImportanceExplanation,)
@@ -13,9 +18,11 @@ class FeatureSelectTransformer(Transformer):
         Initializes the transformer
 
         Args:
-            columns (array-like or Index):
-                An ordered list of columns to select
+            columns (dataframe column label type or list of dataframe column label type):
+                Label of column to select, or an ordered list of column labels to select
         """
+        if columns is not None and not isinstance(columns, (list, tuple, np.ndarray, pd.Index)):
+            columns = [columns]
         self.columns = columns
         self.dropped_columns = []
 
@@ -91,9 +98,11 @@ class ColumnDropTransformer(Transformer):
         Initializes the transformer
 
         Args:
-            columns (array-like or Index):
-                An ordered list of columns to drop
+            columns (dataframe column label type or list of dataframe column label type):
+                Label of column to select, or an ordered list of column labels to select
         """
+        if columns is not None and not isinstance(columns, collections.Sequence):
+            columns = [columns]
         self.dropped_columns = columns
 
     def data_transform(self, x):

--- a/pyreal/transformers/one_hot_encode.py
+++ b/pyreal/transformers/one_hot_encode.py
@@ -100,10 +100,12 @@ class OneHotEncoder(Transformer):
         Initializes the base one-hot encoder
 
         Args:
-            columns (array-like):
-                List of columns to encode
+            columns (dataframe column label type or list of dataframe column label type):
+                Label of column to select, or an ordered list of column labels to select
         """
         self.ohe = SklearnOneHotEncoder(sparse=False)
+        if columns is not None and not isinstance(columns, (list, tuple, np.ndarray, pd.Index)):
+            columns = [columns]
         self.columns = columns
         self.is_fit = False
 

--- a/tests/transformers/test_feature_select.py
+++ b/tests/transformers/test_feature_select.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -28,3 +29,15 @@ def test_transform_column_drop_transformer(transformer_test_data):
                                            [3, 0],
                                            [7, 2]], columns=["B", "D"])
     assert_frame_equal(transformed_x, expected_transformed_x)
+
+
+def test_fit_transform_feature_select_transformer_other_formats(transformer_test_data):
+    for columns in ["A", np.array(["A"]), pd.Index(["A"])]:
+        fs_transformer = FeatureSelectTransformer(columns="A")
+        fs_transformer.fit(transformer_test_data["x"])
+        assert (set(fs_transformer.dropped_columns) == {"B", "C", "D"})
+        transformed_x = fs_transformer.transform(transformer_test_data["x"])
+        expected_transformed_x = pd.DataFrame([[2],
+                                               [4],
+                                               [6]], columns=["A"])
+        assert_frame_equal(transformed_x, expected_transformed_x)


### PR DESCRIPTION
### Closing issues

Closes #144 

### Description

This PR allows `OneHotEncoders` and `FeatureSelectTransformers` to take a scalar (column label) as a parameter to `init()`, to increase user friendliness

### Test Plan

All tests continue to pass

