### PR TITLE
Update fit_transformers to return transformed data

### DIFF
--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -8,15 +8,17 @@ from pyreal.types.explanations.dataframe import (
 def fit_transformers(transformers, x):
     """
     Fit a set of transformers in-place, transforming the data after each fit. Checks if each
-    transformer has a fit function and if so, calls it.
+    transformer has a fit function and if so, calls it. Returns the data after being transformed
+    by the final transformer.
     Args:
-        transformers (list of Transformers):
+        transformers (Transformer or list of Transformers):
             List of transformers to fit, in order
         x (DataFrame of shape (n_instances, n_features)):
             Dataset to fit on.
 
     Returns:
-        None
+        DataFrame of shape (n_instances, n_features)
+            `x` after being transformed by all transformers
     """
     x_transform = x.copy()
     if not isinstance(transformers, list):
@@ -26,6 +28,7 @@ def fit_transformers(transformers, x):
         if callable(fit_func):
             fit_func(x_transform)
         x_transform = transformer.transform(x_transform)
+    return x_transform
 
 
 def run_transformers(transformers, x):
@@ -33,7 +36,7 @@ def run_transformers(transformers, x):
     Run a series of transformers on x_orig
 
     Args:
-        transformers (list of Transformers):
+        transformers (Transformer or list of Transformers):
             List of transformers to fit, in order
         x (DataFrame of shape (n_instances, n_features)):
             Dataset to transform

--- a/tests/transformers/test_base.py
+++ b/tests/transformers/test_base.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from pyreal.transformers import (
+    FeatureSelectTransformer, OneHotEncoder, fit_transformers, run_transformers,)
+
+
+def test_fit_feature_select_transformer():
+    x_orig = pd.DataFrame([
+        [1, 1, 1],
+        [2, 2, 2],
+        [3, 3, 3]
+    ], columns=["A", "B", "C"])
+
+    ohe_transformer = OneHotEncoder(columns=["A"])
+    fs_transformer = FeatureSelectTransformer(columns=["A_1", "A_2", "C"])
+
+    transformers = [ohe_transformer, fs_transformer]
+
+    expected_result = pd.DataFrame([
+        [1, 0, 1],
+        [0, 1, 2],
+        [0, 0, 3]
+    ], columns=["A_1", "A_2", "C"])
+
+    result_fit = fit_transformers(transformers, x_orig)
+    assert_frame_equal(result_fit, expected_result, check_dtype=False)
+
+    result_run = run_transformers(transformers, x_orig)
+    assert_frame_equal(result_run, expected_result, check_dtype=False)

--- a/tutorials/student/student_performance_lfc_gfi.ipynb
+++ b/tutorials/student/student_performance_lfc_gfi.ipynb
@@ -123,7 +123,7 @@
     "        x_transform[\"famsize\"] = x_transform[\"famsize\"].cat.reorder_categories(['LE3', 'GT3'])\n",
     "        x_transform[\"famsize\"] = x_transform[\"famsize\"].cat.codes\n",
     "        return x_transform\n",
-    "    \n",
+    "\n",
     "    def inverse_transform_explanation(self, explanation):\n",
     "        return explanation\n",
     "\n",


### PR DESCRIPTION
### Closing issues

Closes #132 

### Description

Because the `transformers/base::fit_tranformers` function already must transform the data with all transformers in order to fit them, this PR simply has this function return the final result. Users may decide to store this result if they need it.

### Test Plan

All unit tests that use this function continue to function as expected. A new test has been added for `run_transformers` and `fit_transformers`. 

