### PR TITLE
Fix multitype imputer

### DIFF
--- a/pyreal/transformers/impute.py
+++ b/pyreal/transformers/impute.py
@@ -55,22 +55,33 @@ class MultiTypeImputer(Transformer):
             DataFrame of shape (n_instances, n_transformed_features):
                 The imputed dataset
         """
+        series_flag = False
+        name = None
         if isinstance(x, pd.Series):
+            series_flag = True
+            name = x.name
             x = x.to_frame().T
 
         if len(self.categorical_cols) == 0:
             new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])
-            return pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index)
+            result = pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index)
 
-        if len(self.numeric_cols) == 0:
+        elif len(self.numeric_cols) == 0:
             new_categorical_cols = self.categorical_imputer.transform(x[self.categorical_cols])
-            return pd.DataFrame(new_categorical_cols, columns=self.categorical_cols, index=x.index)
+            result = pd.DataFrame(new_categorical_cols, columns=self.categorical_cols, index=x.index)
 
-        new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])
-        new_categorical_cols = self.categorical_imputer.transform(x[self.categorical_cols])
-        return pd.concat([pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index),
-                          pd.DataFrame(new_categorical_cols, columns=self.categorical_cols,
-                                       index=x.index)], axis=1)
+        else:
+            new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])
+            new_categorical_cols = self.categorical_imputer.transform(x[self.categorical_cols])
+            result = pd.concat([
+                pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index),
+                pd.DataFrame(new_categorical_cols, columns=self.categorical_cols, index=x.index)],
+                axis=1)
+
+        if series_flag:
+            result = result.squeeze()
+            result.name = name
+        return result
 
     def transform_explanation(self, explanation):
         """

--- a/pyreal/transformers/impute.py
+++ b/pyreal/transformers/impute.py
@@ -55,6 +55,9 @@ class MultiTypeImputer(Transformer):
             DataFrame of shape (n_instances, n_transformed_features):
                 The imputed dataset
         """
+        if isinstance(x, pd.Series):
+            x = x.to_frame().T
+
         if len(self.categorical_cols) == 0:
             new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])
             return pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index)

--- a/pyreal/transformers/impute.py
+++ b/pyreal/transformers/impute.py
@@ -68,7 +68,8 @@ class MultiTypeImputer(Transformer):
 
         elif len(self.numeric_cols) == 0:
             new_categorical_cols = self.categorical_imputer.transform(x[self.categorical_cols])
-            result = pd.DataFrame(new_categorical_cols, columns=self.categorical_cols, index=x.index)
+            result = pd.DataFrame(
+                new_categorical_cols, columns=self.categorical_cols, index=x.index)
 
         else:
             new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])

--- a/tests/transformers/test_impute.py
+++ b/tests/transformers/test_impute.py
@@ -24,3 +24,41 @@ def test_fit_transform_multitype_imputer():
 
     row_result = imputer.transform(row)
     assert_frame_equal(expected_row, row_result, check_dtype=False)
+
+
+def test_fit_transform_multitype_imputer_cat_only():
+    imputer = MultiTypeImputer()
+    x = pd.DataFrame([['a', '+'],
+                      ['a', '-'],
+                      [np.nan, '-']], columns=["D", "E"])
+
+    expected_result = pd.DataFrame([['a', '+'],
+                                    ['a', '-'],
+                                    ['a', '-']], columns=["D", "E"])
+    result = imputer.fit_transform(x)
+    assert_frame_equal(expected_result, result, check_dtype=False)
+
+    row = pd.Series([np.nan, '+'], index=["D", "E"])
+    expected_row = pd.DataFrame([['a', '+']], columns=["D", "E"])
+
+    row_result = imputer.transform(row)
+    assert_frame_equal(expected_row, row_result, check_dtype=False)
+
+
+def test_fit_transform_multitype_imputer_num_only():
+    imputer = MultiTypeImputer()
+    x = pd.DataFrame([[3, 1],
+                      [1, 1],
+                      [np.nan, 1]], columns=["A", "B"])
+
+    expected_result = pd.DataFrame([[3, 1],
+                                    [1, 1],
+                                    [2, 1]], columns=["A", "B"])
+    result = imputer.fit_transform(x)
+    assert_frame_equal(expected_result, result, check_dtype=False)
+
+    row = pd.Series([np.nan, 2], index=["A", "B"])
+    expected_row = pd.DataFrame([[2, 2]], columns=["A", "B"])
+
+    row_result = imputer.transform(row)
+    assert_frame_equal(expected_row, row_result, check_dtype=False)

--- a/tests/transformers/test_impute.py
+++ b/tests/transformers/test_impute.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pyreal.transformers import MultiTypeImputer
 
@@ -20,10 +20,10 @@ def test_fit_transform_multitype_imputer():
     assert_frame_equal(expected_result, result, check_dtype=False)
 
     row = pd.Series([3, 1, np.nan, 'a', '+'], index=["A", "B", "C", "D", "E"])
-    expected_row = pd.DataFrame([[3, 1, 4, 'a', '+']], columns=["A", "B", "C", "D", "E"])
+    expected_row = pd.Series([3, 1, 4, 'a', '+'], index=["A", "B", "C", "D", "E"])
 
     row_result = imputer.transform(row)
-    assert_frame_equal(expected_row, row_result, check_dtype=False)
+    assert_series_equal(expected_row, row_result, check_dtype=False)
 
 
 def test_fit_transform_multitype_imputer_cat_only():
@@ -39,10 +39,10 @@ def test_fit_transform_multitype_imputer_cat_only():
     assert_frame_equal(expected_result, result, check_dtype=False)
 
     row = pd.Series([np.nan, '+'], index=["D", "E"])
-    expected_row = pd.DataFrame([['a', '+']], columns=["D", "E"])
+    expected_row = pd.Series(['a', '+'], index=["D", "E"])
 
     row_result = imputer.transform(row)
-    assert_frame_equal(expected_row, row_result, check_dtype=False)
+    assert_series_equal(expected_row, row_result, check_dtype=False)
 
 
 def test_fit_transform_multitype_imputer_num_only():
@@ -58,7 +58,7 @@ def test_fit_transform_multitype_imputer_num_only():
     assert_frame_equal(expected_result, result, check_dtype=False)
 
     row = pd.Series([np.nan, 2], index=["A", "B"])
-    expected_row = pd.DataFrame([[2, 2]], columns=["A", "B"])
+    expected_row = pd.Series([2, 2], index=["A", "B"])
 
     row_result = imputer.transform(row)
-    assert_frame_equal(expected_row, row_result, check_dtype=False)
+    assert_series_equal(expected_row, row_result, check_dtype=False)

--- a/tests/transformers/test_impute.py
+++ b/tests/transformers/test_impute.py
@@ -18,3 +18,9 @@ def test_fit_transform_multitype_imputer():
                                     [3, 9, 6, 'b', '+']], columns=["A", "B", "C", "D", "E"])
     result = imputer.fit_transform(x)
     assert_frame_equal(expected_result, result, check_dtype=False)
+
+    row = pd.Series([3, 1, np.nan, 'a', '+'], index=["A", "B", "C", "D", "E"])
+    expected_row = pd.DataFrame([[3, 1, 4, 'a', '+']], columns=["A", "B", "C", "D", "E"])
+
+    row_result = imputer.transform(row)
+    assert_frame_equal(expected_row, row_result, check_dtype=False)


### PR DESCRIPTION
### Closing issues

Closes #152 

### Description

Converts inputs to `MultiTypeImputer.data_transform()` to DataFrames to work on, then converts back to a Series as needed. 

### Test Plan

Added two new unit tests and updated an existing one to test on Series.

