### PR TITLE
Report breaking transformer

### DIFF
--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -256,6 +256,10 @@ class Explainer(ABC):
                     if self.stop_on_missing_transform:
                         print("Stopping explanation transform process")
                         return explanation
+                except BaseException as err:
+                    print("Error in %s.inverse_transform_explanation:\n" % t.__class__)
+                    raise err
+
         for t in te_transformers:
             transform_func = getattr(t, "transform_explanation", None)
             try:
@@ -267,6 +271,9 @@ class Explainer(ABC):
                 if self.stop_on_missing_transform:
                     print("Stopping explanation transform process")
                     return explanation
+            except BaseException as err:
+                print("Error in %s.transform_explanation:\n" % t.__class__)
+                raise err
         return explanation
 
     def model_predict(self, x_orig):

--- a/tests/explainers/test_base_explainer.py
+++ b/tests/explainers/test_base_explainer.py
@@ -89,3 +89,16 @@ def test_evaluate_model(regression_no_transforms):
                                          y_orig=new_y)
     score = explainer.evaluate_model("accuracy")
     assert abs(score - .6667) <= 0.0001
+
+
+def test_break(regression_no_transforms):
+    feature_select = FeatureSelectTransformer(["A"])
+    feature_select.fit(pd.DataFrame([[1, 2, 3]], columns=["A", "B", "C"]))
+
+    explanation = 10  # invalid explanation type
+
+    explainer = LocalFeatureContribution(regression_no_transforms["model"],
+                                         regression_no_transforms["x"],
+                                         transformers=feature_select)
+    with pytest.raises(ValueError):
+        explainer.transform_explanation(explanation)


### PR DESCRIPTION
### Closing issues

Closes #151 

### Description

Adds a helpful error message that explains which Transformer/transform function is breaking during the `transform_explanation` process. For now this is just printed; it will be switched to the logging process once #105 is addressed.

### Test Plan

A new unit test was added that activates this message - the message itself must be checked manually.

