### PR TITLE
Updating docstrings for Local Feature Contribution return

### DIFF
--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -235,8 +235,8 @@ class ExplainerBase(ABC):
             type varies by subclass
                 The interpretable form of the explanation
             DataFrame of shape (n_instances, x_orig_feature_count)
-                If `x_orig` is not None, return `x_orig` transformed to whatever feature space
-                the final explanation reached.
+                If `x_orig` is not None, return `x_orig` transformed to the state of the final
+                explanation. Not returned if `x_orig` is None.
         """
         convert_x = (x_orig is not None)
         if self.return_original_explanation:

--- a/pyreal/explainers/lfc/base.py
+++ b/pyreal/explainers/lfc/base.py
@@ -46,6 +46,8 @@ class LocalFeatureContributionsBase(ExplainerBase, ABC):
         Returns:
             DataFrame of shape (n_instances, n_features)
                 Contribution of each feature for each instance
+            DataFrame of shape (n_instances, x_orig_feature_count)
+                `x_orig` transformed to the state of the final explanation
         """
         series = False
         name = None


### PR DESCRIPTION
### Closing issues

Closes #165 

### Description

Updating docstrings of `LocalFeatureContribution.produce()` to specify that tuple return type. Fixing wording of `.produce()` docstring.

### Test Plan

All existing tests continue to pass. No new tests are required as change is to docs only.

