### PR TITLE
imputer transformer now supports None

### DIFF
--- a/pyreal/transformers/impute.py
+++ b/pyreal/transformers/impute.py
@@ -64,7 +64,7 @@ class MultiTypeImputer(Transformer):
             series_flag = True
             name = x.name
             x = x.to_frame().T
-
+        x = x.fillna(value=np.nan)
         if len(self.categorical_cols) == 0:
             new_numeric_cols = self.numeric_imputer.transform(x[self.numeric_cols])
             result = pd.DataFrame(new_numeric_cols, columns=self.numeric_cols, index=x.index)

--- a/tests/transformers/test_impute.py
+++ b/tests/transformers/test_impute.py
@@ -5,14 +5,13 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from pyreal.transformers import MultiTypeImputer
 
 
-# TODO: Issue  # 100. Replace an np.nan with None
 def test_fit_transform_multitype_imputer():
     imputer = MultiTypeImputer()
     x = pd.DataFrame(
         [
-            [3, 1, np.nan, "a", "+"],
+            [3, 1, None, "a", "+"],
             [np.nan, 3, 4, "a", "-"],
-            [6, 7, 2, np.nan, "-"],
+            [6, 7, 2, None, "-"],
             [3, 9, 6, "b", "+"],
         ],
         columns=["A", "B", "C", "D", "E"],


### PR DESCRIPTION
I added the process of changing values of `None` to `np.nan` to the Imputer. Data with both np.nan and None pass unit test.
