### PR TITLE
Updating README to link to gitbooks docs and cleaning old docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 Library for evaluating and deploying machine learning explanations.
 
 - License: MIT
-- Documentation: https://sibyl-dev.github.io/pyreal
+- Documentation: https://pyreal.gitbook.io/pyreal
+- API Documentation: https://sibyl-ml.dev/pyreal/api_reference/index.html
 - Homepage: https://sibyl-ml.dev/
 
 # Overview

--- a/docs/api_reference/explanation_types.rst
+++ b/docs/api_reference/explanation_types.rst
@@ -18,45 +18,45 @@ DataFrame Explanation Type
 .. autosummary::
     :toctree: api/
 
-    dataframe.FeatureBased
-    dataframe.FeatureBased.get
-    dataframe.FeatureBased.validate
+    feature_based.FeatureBased
+    feature_based.FeatureBased.get
+    feature_based.FeatureBased.validate
 
 Feature Importance Explanation Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: api/
 
-    dataframe.FeatureImportanceExplanation
-    dataframe.FeatureImportanceExplanation.get
-    dataframe.FeatureImportanceExplanation.validate
+    feature_based.FeatureImportanceExplanation
+    feature_based.FeatureImportanceExplanation.get
+    feature_based.FeatureImportanceExplanation.validate
 
 Additive Feature Importance Explanation Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: api/
 
-    dataframe.AdditiveFeatureImportanceExplanation
-    dataframe.AdditiveFeatureImportanceExplanation.get
-    dataframe.AdditiveFeatureImportanceExplanation.validate
+    feature_based.AdditiveFeatureImportanceExplanation
+    feature_based.AdditiveFeatureImportanceExplanation.get
+    feature_based.AdditiveFeatureImportanceExplanation.validate
 
 Feature Contribution Explanation Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: api/
 
-    dataframe.FeatureContributionExplanation
-    dataframe.FeatureContributionExplanation.get
-    dataframe.FeatureContributionExplanation.validate
+    feature_based.FeatureContributionExplanation
+    feature_based.FeatureContributionExplanation.get
+    feature_based.FeatureContributionExplanation.validate
 
 Additive Feature Contribution Explanation Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: api/
 
-    dataframe.AdditiveFeatureContributionExplanation
-    dataframe.AdditiveFeatureContributionExplanation.get
-    dataframe.AdditiveFeatureContributionExplanation.validate
+    feature_based.AdditiveFeatureContributionExplanation
+    feature_based.AdditiveFeatureContributionExplanation.get
+    feature_based.AdditiveFeatureContributionExplanation.validate
 
 Decision Tree Explanation Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api_reference/generic_explainer.rst
+++ b/docs/api_reference/generic_explainer.rst
@@ -1,7 +1,7 @@
 .. _pyreal.generic_explainer:
 
-Default Explainer
-=========
+Generic Explainer
+=================
 .. currentmodule:: pyreal.explainers
 
 Generic Explainer

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,14 +5,12 @@
    <i>An open source project from Data to AI Lab at MIT.</i>
    </p>
 
-Pyreal - Applied Explainability
+Pyreal Documentation
 ===============================
 
--  License:
--  Development Status:
-
--  Documentation: https://sibyl-dev.github.io/pyreal/
--  Homepage: https://github.com/sibyl-dev/pyreal
+-  License: MIT
+-  Documentation: https://pyreal.gitbook.io/pyreal
+-  Github: https://github.com/sibyl-dev/pyreal
 
 Overview
 --------
@@ -21,20 +19,14 @@ Overview
 handle all the transforming logic, in order to provide a human-interpretable explanation from any original
 data form.
 
+`API Reference <api_reference/index.html>`_
+
 ..
     Current functionality and features:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ..
     - functionality
 
-Explore Pyreal
----------------
-
-* `Getting Started <getting_started/index.html>`_
-* `User Guides <user_guides/index.html>`_
-* `API Reference <api_reference/index.html>`_
-* `Developer Guides <developer_guides/index.html>`_
-* `Release Notes <history.html>`_
 
 --------------
 
@@ -43,7 +35,4 @@ Explore Pyreal
     :hidden:
     :titlesonly:
 
-    getting_started/index
-    user_guides/index
     api_reference/index
-    developer_guides/index


### PR DESCRIPTION
### Closing issues

Closes #198 

### Description

This PR updates the documentation link to the new gitbooks, and removes repeated content from the old docs, which now house only the API documentation

### Test Plan

Docs continue to build as expected

