### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enables Dependabot support for the python dependencies. 

If available, either with standard `pyproject.toml` project or the poetry dependency specification, PRs will be created with new pins. Note, this does not affect the lock file and `poetry update` will still have to be called for determinism. In this situation Dependabot does the grunt work of figuring out when and what dependencies are available to upgrade,
