### PR TITLE
Pad time series transformer

### DIFF
--- a/docs/api_reference/transformer.rst
+++ b/docs/api_reference/transformer.rst
@@ -109,3 +109,15 @@ Wrappers
     DataFrameWrapper.fit_transform
     DataFrameWrapper.transform_explanation
 
+Time Series Padders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+    :toctree: api/
+
+    TimeSeriesPadder
+    TimeSeriesPadder.fit
+    TimeSeriesPadder.data_transform
+    TimeSeriesPadder.transform
+    TimeSeriesPadder.fit_transform
+    TimeSeriesPadder.transform_explanation
+

--- a/pyreal/transformers/__init__.py
+++ b/pyreal/transformers/__init__.py
@@ -56,5 +56,5 @@ __all__ = [
     "Numpy3dToMultiIndexFrame",
     "Numpy3dToNestedFrame",
     "Pandas2dToMultiIndexFrame",
-    "TimeSeriesPadder"
+    "TimeSeriesPadder",
 ]

--- a/pyreal/transformers/__init__.py
+++ b/pyreal/transformers/__init__.py
@@ -28,6 +28,7 @@ from pyreal.transformers.time_series_formatter import (
     Pandas2dToMultiIndexFrame,
 )
 from pyreal.transformers.wrappers import DataFrameWrapper
+from pyreal.transformers.pad import TimeSeriesPadder
 
 __all__ = [
     "Transformer",
@@ -55,4 +56,5 @@ __all__ = [
     "Numpy3dToMultiIndexFrame",
     "Numpy3dToNestedFrame",
     "Pandas2dToMultiIndexFrame",
+    "TimeSeriesPadder"
 ]

--- a/pyreal/transformers/pad.py
+++ b/pyreal/transformers/pad.py
@@ -1,0 +1,70 @@
+from pyreal.transformers import Transformer
+import numpy as np
+import pandas as pd
+
+
+class TimeSeriesPadder(Transformer):
+    """
+    A transformer that pads and truncates variable-length time series to equal lengths
+    """
+
+    def __init__(self, value, length=None, **kwargs):
+        """
+        Initializes the transformer
+
+        Args:
+            length (int):
+                Length to pad/truncate time series sequences to. If none, pad to maximum length in
+                fitting dataset
+            value (Union[int, float, complex, ndarray, Iterable]):
+                Object value to pad with
+
+        """
+        if length is not None and length <= 0:
+            raise ValueError("Length must be integer >= 0")
+        self.length = length
+        self.value = value
+        super().__init__(**kwargs)
+
+    def fit(self, x, **params):
+        """
+        Determines the length to pad to if not set
+
+        Args:
+            x (DataFrame or numpy array of shape (n_instances, n_features)):
+                The dataset to fit on
+        Returns:
+            None
+
+        """
+        if self.length is None:
+            if isinstance(x, pd.DataFrame):
+                self.length = x.shape[1]
+            else:
+                self.length = len(max(x, key=lambda x_: len(x_)))
+        super().fit(x)
+
+    def data_transform(self, x):
+        """
+        Reorders and selects the features in x. If no length has been set
+        and the transformer has not been fit, pad to the longest subsequence length
+
+        Args:
+            x (numpy array of shape (n_instances, n_features)):
+                The data to transform
+        Returns:
+            numpy array of shape (n_instances, len(columns)):
+                The data with features selected and reordered
+        """
+        if self.length is None:
+            length = len(max(x, key=lambda x_: len(x_)))
+        else:
+            length = self.length
+        z = np.full([len(x), length], self.value)
+        for i, j in enumerate(x):
+            if len(j) < z.shape[1]:
+                z[i][0:len(j)] = j
+            else:
+                z[i][0:length] = j[0:length]
+        return z
+

--- a/pyreal/transformers/pad.py
+++ b/pyreal/transformers/pad.py
@@ -1,6 +1,7 @@
-from pyreal.transformers import Transformer
 import numpy as np
 import pandas as pd
+
+from pyreal.transformers import Transformer
 
 
 class TimeSeriesPadder(Transformer):
@@ -63,8 +64,7 @@ class TimeSeriesPadder(Transformer):
         z = np.full([len(x), length], self.value)
         for i, j in enumerate(x):
             if len(j) < z.shape[1]:
-                z[i][0:len(j)] = j
+                z[i][0 : len(j)] = j
             else:
                 z[i][0:length] = j[0:length]
         return z
-

--- a/tests/transformers/test_pad.py
+++ b/tests/transformers/test_pad.py
@@ -1,0 +1,92 @@
+import pandas as pd
+import numpy as np
+from pandas.testing import assert_frame_equal
+
+from pyreal.transformers import TimeSeriesPadder
+
+X = np.array([[1, 1],
+              [1],
+              [1, 1, 1]])
+
+
+def test_fit_transform_pad_to_length(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0, length=5)
+    x_padded = np.array([[1, 1, 0, 0, 0],
+                         [1, 0, 0, 0, 0],
+                         [1, 1, 1, 0, 0]])
+    transformer.fit(transformer_test_data["x"])
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_pad_to_longest_fit(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0)
+    x_padded = np.array([[1, 1, 0, 0],
+                         [1, 0, 0, 0],
+                         [1, 1, 1, 0]])
+    transformer.fit(np.array(transformer_test_data["x"]))  # longest is length 4
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+    transformer.fit(transformer_test_data["x"])  # longest is length 4
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_pad_to_longest_transform(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0)
+    x_padded = np.array([[1, 1, 0],
+                         [1, 0, 0],
+                         [1, 1, 1]])
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_cut_to_length(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0, length=1)
+    x_padded = np.array([[1],
+                         [1],
+                         [1]])
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_cut_and_pad_to_length(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0, length=2)
+    x_padded = np.array([[1, 1],
+                         [1, 0],
+                         [1, 1]])
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_cut_and_pad_to_length_fit(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0)
+    x_padded = np.array([[1, 1],
+                         [1, 0],
+                         [1, 1]])
+    transformer.fit(np.array([[1, 1]]))
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+def test_fit_transform_fit_with_length_defined(transformer_test_data):
+    transformer = TimeSeriesPadder(value=0, length=2)
+    x_padded = np.array([[1, 1],
+                         [1, 0],
+                         [1, 1]])
+    transformer.fit(np.array(transformer_test_data["x"]))  # shouldn't override set length
+    x_trans = transformer.transform(X)
+
+    np.testing.assert_array_equal(x_padded, x_trans)
+
+
+
+

--- a/tests/transformers/test_pad.py
+++ b/tests/transformers/test_pad.py
@@ -1,19 +1,13 @@
-import pandas as pd
 import numpy as np
-from pandas.testing import assert_frame_equal
 
 from pyreal.transformers import TimeSeriesPadder
 
-X = np.array([[1, 1],
-              [1],
-              [1, 1, 1]])
+X = np.array([[1, 1], [1], [1, 1, 1]])
 
 
 def test_fit_transform_pad_to_length(transformer_test_data):
     transformer = TimeSeriesPadder(value=0, length=5)
-    x_padded = np.array([[1, 1, 0, 0, 0],
-                         [1, 0, 0, 0, 0],
-                         [1, 1, 1, 0, 0]])
+    x_padded = np.array([[1, 1, 0, 0, 0], [1, 0, 0, 0, 0], [1, 1, 1, 0, 0]])
     transformer.fit(transformer_test_data["x"])
     x_trans = transformer.transform(X)
 
@@ -22,9 +16,7 @@ def test_fit_transform_pad_to_length(transformer_test_data):
 
 def test_fit_transform_pad_to_longest_fit(transformer_test_data):
     transformer = TimeSeriesPadder(value=0)
-    x_padded = np.array([[1, 1, 0, 0],
-                         [1, 0, 0, 0],
-                         [1, 1, 1, 0]])
+    x_padded = np.array([[1, 1, 0, 0], [1, 0, 0, 0], [1, 1, 1, 0]])
     transformer.fit(np.array(transformer_test_data["x"]))  # longest is length 4
     x_trans = transformer.transform(X)
 
@@ -38,9 +30,7 @@ def test_fit_transform_pad_to_longest_fit(transformer_test_data):
 
 def test_fit_transform_pad_to_longest_transform(transformer_test_data):
     transformer = TimeSeriesPadder(value=0)
-    x_padded = np.array([[1, 1, 0],
-                         [1, 0, 0],
-                         [1, 1, 1]])
+    x_padded = np.array([[1, 1, 0], [1, 0, 0], [1, 1, 1]])
     x_trans = transformer.transform(X)
 
     np.testing.assert_array_equal(x_padded, x_trans)
@@ -48,9 +38,7 @@ def test_fit_transform_pad_to_longest_transform(transformer_test_data):
 
 def test_fit_transform_cut_to_length(transformer_test_data):
     transformer = TimeSeriesPadder(value=0, length=1)
-    x_padded = np.array([[1],
-                         [1],
-                         [1]])
+    x_padded = np.array([[1], [1], [1]])
     x_trans = transformer.transform(X)
 
     np.testing.assert_array_equal(x_padded, x_trans)
@@ -58,9 +46,7 @@ def test_fit_transform_cut_to_length(transformer_test_data):
 
 def test_fit_transform_cut_and_pad_to_length(transformer_test_data):
     transformer = TimeSeriesPadder(value=0, length=2)
-    x_padded = np.array([[1, 1],
-                         [1, 0],
-                         [1, 1]])
+    x_padded = np.array([[1, 1], [1, 0], [1, 1]])
     x_trans = transformer.transform(X)
 
     np.testing.assert_array_equal(x_padded, x_trans)
@@ -68,9 +54,7 @@ def test_fit_transform_cut_and_pad_to_length(transformer_test_data):
 
 def test_fit_transform_cut_and_pad_to_length_fit(transformer_test_data):
     transformer = TimeSeriesPadder(value=0)
-    x_padded = np.array([[1, 1],
-                         [1, 0],
-                         [1, 1]])
+    x_padded = np.array([[1, 1], [1, 0], [1, 1]])
     transformer.fit(np.array([[1, 1]]))
     x_trans = transformer.transform(X)
 
@@ -79,14 +63,8 @@ def test_fit_transform_cut_and_pad_to_length_fit(transformer_test_data):
 
 def test_fit_transform_fit_with_length_defined(transformer_test_data):
     transformer = TimeSeriesPadder(value=0, length=2)
-    x_padded = np.array([[1, 1],
-                         [1, 0],
-                         [1, 1]])
+    x_padded = np.array([[1, 1], [1, 0], [1, 1]])
     transformer.fit(np.array(transformer_test_data["x"]))  # shouldn't override set length
     x_trans = transformer.transform(X)
 
     np.testing.assert_array_equal(x_padded, x_trans)
-
-
-
-


### PR DESCRIPTION
### Closing issues

Added to support testing for #211 

### Description

Adds a `TimeSeriesPadder` transformer object, that pads or truncates sequences to a common length

### Test Plan

Added a series of unit tests that all pass
