### PR TITLE
Adding tests for realapp prepare functions

### DIFF
--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -428,9 +428,9 @@ class RealApp:
 
     def prepare_feature_contributions(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         shap_type=None,
         training_size=None,
@@ -531,9 +531,9 @@ class RealApp:
 
     def prepare_feature_importance(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         shap_type=None,
         training_size=None,
@@ -629,9 +629,9 @@ class RealApp:
 
     def prepare_similar_examples(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         training_size=None,
     ):

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,5 +1,6 @@
-from pyreal import RealApp
 import pytest
+
+from pyreal import RealApp
 
 
 def test_prepare_global_feature_importance(regression_no_transforms):
@@ -12,8 +13,9 @@ def test_prepare_global_feature_importance(regression_no_transforms):
         realApp.produce_feature_importance()
 
     # Confirm no error
-    realApp.prepare_feature_importance(x_train_orig=regression_no_transforms["x"],
-                                       y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_importance(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_importance()

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,4 +1,22 @@
 from pyreal import RealApp
+import pytest
+
+
+def test_prepare_global_feature_importance(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+
+    with pytest.raises(ValueError):
+        realApp.produce_feature_importance()
+
+    # Confirm no error
+    realApp.prepare_feature_importance(x_train_orig=regression_no_transforms["x"],
+                                       y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_importance()
 
 
 def test_produce_global_feature_importance(regression_no_transforms):

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -37,8 +37,9 @@ def test_prepare_local_feature_contribution(regression_no_transforms):
         realApp.produce_feature_contributions(x)
 
     # Confirm no error
-    realApp.prepare_feature_contributions(x_train_orig=regression_no_transforms["x"],
-                                          y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_contributions(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_contributions(x)

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from pyreal import RealApp
 from pyreal.realapp.realapp import _get_average_or_mode
@@ -23,6 +24,24 @@ def test_average_or_mode():
     result = _get_average_or_mode(mean_only)
     for i in range(len(expected)):
         assert expected[i] == result[i]
+
+
+def test_prepare_local_feature_contribution(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+    x = pd.DataFrame([[2, 10, 10]])
+
+    with pytest.raises(ValueError):
+        realApp.produce_feature_contributions(x)
+
+    # Confirm no error
+    realApp.prepare_feature_contributions(x_train_orig=regression_no_transforms["x"],
+                                          y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_contributions(x)
 
 
 def test_produce_local_feature_contributions(regression_no_transforms):

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
 import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pyreal import RealApp
 
@@ -39,10 +39,9 @@ def test_prepare_similar_examples(regression_no_transforms):
         realApp.produce_similar_examples(x)
 
     # Confirm no error
-    realApp.prepare_similar_examples(x_train_orig=regression_no_transforms["x"],
-                                     y_train=regression_no_transforms["y"])
+    realApp.prepare_similar_examples(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_similar_examples(x)
-
-

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
+import pytest
 
 from pyreal import RealApp
 
@@ -25,3 +26,23 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
     assert "id2" in explanation
     assert_frame_equal(explanation["id2"]["X"], x.iloc[[3, 0], :] + 1)
     assert_series_equal(explanation["id2"]["y"], y.iloc[[3, 0]])
+
+
+def test_prepare_similar_examples(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+    x = pd.DataFrame([[2, 10, 10]])
+
+    with pytest.raises(ValueError):
+        realApp.produce_similar_examples(x)
+
+    # Confirm no error
+    realApp.prepare_similar_examples(x_train_orig=regression_no_transforms["x"],
+                                     y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_similar_examples(x)
+
+


### PR DESCRIPTION
### Closing issues

Closes #363 

### Description

It seems this was technically fixed at one point, but updating to make X and y the first two arguments of the prepare functions as this seems like the more natural order (people will most often not be providing `model_id`)

### Test Plan

Added new unit tests for `prepare` functions
