### PR TITLE
Standardize nn

### DIFF
--- a/pyreal/explainers/example/similar_examples.py
+++ b/pyreal/explainers/example/similar_examples.py
@@ -1,8 +1,8 @@
 from sklearn.neighbors import KDTree
+from sklearn.preprocessing import StandardScaler
 
 from pyreal.explainers.example.base import ExampleBasedBase
 from pyreal.types.explanations.example_based import SimilarExampleExplanation
-from sklearn.preprocessing import StandardScaler
 
 
 class SimilarExamples(ExampleBasedBase):

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -634,6 +634,7 @@ class RealApp:
         model_id=None,
         algorithm=None,
         training_size=None,
+        standardize=False,
     ):
         """
         Initialize and fit a nearest neighbor explainer
@@ -649,6 +650,9 @@ class RealApp:
                 NN algorithm to use (current options: [nn])
             training_size (int):
                 Number of rows to use in fitting explainer
+            standardize (Boolean):
+                If True, standardize data before using it to get similar examples.
+                Recommended if model-ready data is not already standardized
 
         Returns:
             A fit SimilarExamples explainer
@@ -667,6 +671,7 @@ class RealApp:
             classes=self.classes,
             class_descriptions=self.class_descriptions,
             training_size=training_size,
+            standardize=standardize
         )
         explainer.fit(self._get_x_train_orig(x_train_orig), self._get_y_train(y_train))
         self._add_explainer("se", algorithm, explainer)
@@ -679,6 +684,7 @@ class RealApp:
         x_train_orig=None,
         y_train=None,
         n=3,
+        standardize=False,
         algorithm=None,
         force_refit=False,
     ):
@@ -696,6 +702,9 @@ class RealApp:
                 Training targets to fit on, if not provided during initialization
             n (int):
                 Number of similar examples to return
+            standardize (Boolean):
+                If True, standardize data before using it to get similar examples.
+                Recommended if model-ready data is not already standardized
             algorithm (string):
                 Name of algorithm
             force_refit (Boolean):
@@ -718,6 +727,7 @@ class RealApp:
             x_train_orig=x_train_orig,
             y_train=y_train,
             force_refit=force_refit,
+            prepare_kwargs={"standardize": standardize},
             produce_kwargs={"n": n},
         )
 

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -671,7 +671,7 @@ class RealApp:
             classes=self.classes,
             class_descriptions=self.class_descriptions,
             training_size=training_size,
-            standardize=standardize
+            standardize=standardize,
         )
         explainer.fit(self._get_x_train_orig(x_train_orig), self._get_y_train(y_train))
         self._add_explainer("se", algorithm, explainer)

--- a/tests/explainers/example/test_similar_examples.py
+++ b/tests/explainers/example/test_similar_examples.py
@@ -5,13 +5,13 @@ from pyreal.explainers.example.similar_examples import SimilarExamples
 
 
 def test_produce(dummy_model):
-    X = pd.DataFrame([[1, 1, 1], [4, 5, 3], [0, 0, 0], [5, 5, 3]])
+    x = pd.DataFrame([[1, 1, 1], [4, 5, 3], [0, 0, 0], [5, 5, 3]])
     y = pd.Series([0, 1, 0, 1])
 
-    explainer = SimilarExamples(model=dummy_model, x_train_orig=X, y_train=y, fit_on_init=True)
+    explainer = SimilarExamples(model=dummy_model, x_train_orig=x, y_train=y, fit_on_init=True)
     result = explainer.produce(pd.DataFrame([[0, 1, 0]]), n=2)
-    expected_examples = pd.DataFrame([[0, 0, 0], [1, 1, 1]])
-    expected_targets = pd.Series([0, 0])
+    expected_examples = x.iloc[[2, 0], :]
+    expected_targets = y.iloc[[2, 0]]
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 2
     assert_frame_equal(result.get_examples(), expected_examples)

--- a/tests/explainers/example/test_similar_examples.py
+++ b/tests/explainers/example/test_similar_examples.py
@@ -14,8 +14,8 @@ def test_produce(dummy_model):
     expected_targets = pd.Series([0, 0])
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 2
-    assert_frame_equal(result.get_examples().reset_index(drop=True), expected_examples)
-    assert_series_equal(result.get_targets().reset_index(drop=True), expected_targets)
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)
 
 
 def test_produce_with_transforms(regression_one_hot_with_interpret):
@@ -35,10 +35,8 @@ def test_produce_with_transforms(regression_one_hot_with_interpret):
 
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 1
-    assert_frame_equal(result.get_examples().reset_index(drop=True), expected_examples)
-    print(result.get_targets())
-    print(expected_targets)
-    assert_series_equal(result.get_targets().reset_index(drop=True), expected_targets)
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)
 
 
 def test_produce_multiple_with_transforms(regression_one_hot_with_interpret):
@@ -68,3 +66,24 @@ def test_produce_multiple_with_transforms(regression_one_hot_with_interpret):
     assert result.get_examples(row_id=1).shape[0] == 2
     assert_frame_equal(result.get_examples(row_id=1), expected_examples_2)
     assert_series_equal(result.get_targets(row_id=1), expected_targets_2)
+
+
+def test_produce_with_standardize(dummy_model):
+    x = pd.DataFrame([[1, 100], [3, 100], [1, 200], [3, 300]])
+    y = pd.Series([1, 2, 3, 4])
+    explainer = SimilarExamples(
+        model=dummy_model,
+        x_train_orig=x,
+        y_train=y,
+        fit_on_init=True,
+        standardize=True,
+    )
+    result = explainer.produce(pd.DataFrame([[1, 100]]), n=2)
+    expected_examples = x.iloc[[0, 2], :]
+    expected_targets = y.iloc[[0, 2]]
+
+    assert len(result.get_row_ids()) == 1
+    assert result.get_examples(row_id=0).shape[0] == 2
+
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -8,7 +8,7 @@ from pyreal import RealApp
 def test_produce_similar_examples(regression_one_hot_with_interpret):
     x = pd.DataFrame([[2, 0, 0], [6, 6, 6], [6, 7, 8], [2, 0, 1]], columns=["A", "B", "C"])
     y = pd.Series([1, 0, 0, 1])
-    realApp = RealApp(
+    real_app = RealApp(
         regression_one_hot_with_interpret["model"],
         X_train_orig=x,
         y_train=y,
@@ -16,7 +16,7 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
         id_column="ID",
     )
 
-    explanation = realApp.produce_similar_examples(
+    explanation = real_app.produce_similar_examples(
         pd.DataFrame([["id1", 6, 7, 9], ["id2", 2, 1, 1]], columns=["ID", "A", "B", "C"]), n=2
     )
     assert "id1" in explanation
@@ -29,26 +29,26 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
 
 
 def test_prepare_similar_examples(regression_no_transforms):
-    realApp = RealApp(
+    real_app = RealApp(
         regression_no_transforms["model"],
         transformers=regression_no_transforms["transformers"],
     )
     x = pd.DataFrame([[2, 10, 10]])
 
     with pytest.raises(ValueError):
-        realApp.produce_similar_examples(x)
+        real_app.produce_similar_examples(x)
 
     # Confirm no error
-    realApp.prepare_similar_examples(
+    real_app.prepare_similar_examples(
         x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
     )
 
     # Confirm explainer was prepped and now works without being given data
-    realApp.produce_similar_examples(x)
+    real_app.produce_similar_examples(x)
 
 
 def test_prepare_similar_examples_with_id_column(regression_no_transforms):
-    realApp = RealApp(
+    real_app = RealApp(
         regression_no_transforms["model"],
         transformers=regression_no_transforms["transformers"],
         id_column="ID",
@@ -59,7 +59,22 @@ def test_prepare_similar_examples_with_id_column(regression_no_transforms):
     )
 
     # Confirm no error
-    realApp.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
+    real_app.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
 
     # Confirm explainer was prepped and now works without being given data
-    realApp.produce_similar_examples(x_multi_dim, n=1)
+    real_app.produce_similar_examples(x_multi_dim, n=1)
+
+
+def test_produce_similar_examples_with_standardization(dummy_model):
+    x = pd.DataFrame([[1, 100], [3, 100], [1, 200], [3, 300]])
+    y = pd.Series([1, 2, 3, 4])
+    real_app = RealApp(
+        dummy_model,
+        X_train_orig=x,
+        y_train=y,
+    )
+
+    explanation = real_app.produce_similar_examples(pd.DataFrame([[1, 100]]), n=2, standardize=True)
+
+    assert_frame_equal(explanation[0]["X"], x.iloc[[0, 2], :])
+    assert_series_equal(explanation[0]["y"], y.iloc[[0, 2]])

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -74,7 +74,9 @@ def test_produce_similar_examples_with_standardization(dummy_model):
         y_train=y,
     )
 
-    explanation = real_app.produce_similar_examples(pd.DataFrame([[1, 100]]), n=2, standardize=True)
+    explanation = real_app.produce_similar_examples(
+        pd.DataFrame([[1, 100]]), n=2, standardize=True
+    )
 
     assert_frame_equal(explanation[0]["X"], x.iloc[[0, 2], :])
     assert_series_equal(explanation[0]["y"], y.iloc[[0, 2]])


### PR DESCRIPTION
### Closing issues

Closes #419 

### Description

With this PR, the similar examples explainer accepts a `standardize` parameter. If this parameter is set to True, the explainer will automatically standardize the model-ready data right before getting neighbors. Realapp objects will also accept this parameter, which they then send to the wrapped explainer.

### Test Plan

Added unit tests that confirm standardization is working correctly (the produce function was confirmed to return a different answer and fail the test is standardization was not being applied).

