### PR TITLE
Release v0.4.3

### DIFF
--- a/docs/api_reference/transformer.rst
+++ b/docs/api_reference/transformer.rst
@@ -14,6 +14,7 @@ Base Transformer
     Transformer.data_transform
     Transformer.transform
     Transformer.fit_transform
+    Transformer.inverse_transform
     Transformer.transform_explanation
 
 Feature Select Transformer
@@ -50,18 +51,21 @@ One-Hot Encoders
     OneHotEncoder.data_transform
     OneHotEncoder.transform
     OneHotEncoder.fit_transform
+    OneHotEncoder.inverse_transform
     OneHotEncoder.transform_explanation
     MappingsOneHotEncoder
     MappingsOneHotEncoder.fit
     MappingsOneHotEncoder.data_transform
     MappingsOneHotEncoder.transform
     MappingsOneHotEncoder.fit_transform
+    MappingsOneHotEncoder.inverse_transform
     MappingsOneHotEncoder.transform_explanation
     MappingsOneHotDecoder
     MappingsOneHotDecoder.fit
     MappingsOneHotDecoder.data_transform
     MappingsOneHotDecoder.transform
     MappingsOneHotDecoder.fit_transform
+    MappingsOneHotDecoder.inverse_transform
     MappingsOneHotDecoder.transform_explanation
     Mappings
     Mappings.generate_mappings
@@ -119,6 +123,7 @@ Wrappers
     DataFrameWrapper.data_transform
     DataFrameWrapper.transform
     DataFrameWrapper.fit_transform
+    DataFrameWrapper.inverse_transform
     DataFrameWrapper.transform_explanation
 
 Time Series Padders

--- a/poetry.lock
+++ b/poetry.lock
@@ -2649,13 +2649,13 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.3.2"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
-    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2147,36 +2147,36 @@ files = [
 
 [[package]]
 name = "pandas"
-version = "2.0.2"
+version = "2.0.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pandas-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ebb9f1c22ddb828e7fd017ea265a59d80461d5a79154b49a4207bd17514d122"},
-    {file = "pandas-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1eb09a242184092f424b2edd06eb2b99d06dc07eeddff9929e8667d4ed44e181"},
-    {file = "pandas-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7319b6e68de14e6209460f72a8d1ef13c09fb3d3ef6c37c1e65b35d50b5c145"},
-    {file = "pandas-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd46bde7309088481b1cf9c58e3f0e204b9ff9e3244f441accd220dd3365ce7c"},
-    {file = "pandas-2.0.2-cp310-cp310-win32.whl", hash = "sha256:51a93d422fbb1bd04b67639ba4b5368dffc26923f3ea32a275d2cc450f1d1c86"},
-    {file = "pandas-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:66d00300f188fa5de73f92d5725ced162488f6dc6ad4cecfe4144ca29debe3b8"},
-    {file = "pandas-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:02755de164da6827764ceb3bbc5f64b35cb12394b1024fdf88704d0fa06e0e2f"},
-    {file = "pandas-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0a1e0576611641acde15c2322228d138258f236d14b749ad9af498ab69089e2d"},
-    {file = "pandas-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6b5f14cd24a2ed06e14255ff40fe2ea0cfaef79a8dd68069b7ace74bd6acbba"},
-    {file = "pandas-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50e451932b3011b61d2961b4185382c92cc8c6ee4658dcd4f320687bb2d000ee"},
-    {file = "pandas-2.0.2-cp311-cp311-win32.whl", hash = "sha256:7b21cb72958fc49ad757685db1919021d99650d7aaba676576c9e88d3889d456"},
-    {file = "pandas-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:c4af689352c4fe3d75b2834933ee9d0ccdbf5d7a8a7264f0ce9524e877820c08"},
-    {file = "pandas-2.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:69167693cb8f9b3fc060956a5d0a0a8dbfed5f980d9fd2c306fb5b9c855c814c"},
-    {file = "pandas-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:30a89d0fec4263ccbf96f68592fd668939481854d2ff9da709d32a047689393b"},
-    {file = "pandas-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a18e5c72b989ff0f7197707ceddc99828320d0ca22ab50dd1b9e37db45b010c0"},
-    {file = "pandas-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7376e13d28eb16752c398ca1d36ccfe52bf7e887067af9a0474de6331dd948d2"},
-    {file = "pandas-2.0.2-cp38-cp38-win32.whl", hash = "sha256:6d6d10c2142d11d40d6e6c0a190b1f89f525bcf85564707e31b0a39e3b398e08"},
-    {file = "pandas-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:e69140bc2d29a8556f55445c15f5794490852af3de0f609a24003ef174528b79"},
-    {file = "pandas-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b42b120458636a981077cfcfa8568c031b3e8709701315e2bfa866324a83efa8"},
-    {file = "pandas-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f908a77cbeef9bbd646bd4b81214cbef9ac3dda4181d5092a4aa9797d1bc7774"},
-    {file = "pandas-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:713f2f70abcdade1ddd68fc91577cb090b3544b07ceba78a12f799355a13ee44"},
-    {file = "pandas-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf3f0c361a4270185baa89ec7ab92ecaa355fe783791457077473f974f654df5"},
-    {file = "pandas-2.0.2-cp39-cp39-win32.whl", hash = "sha256:598e9020d85a8cdbaa1815eb325a91cfff2bb2b23c1442549b8a3668e36f0f77"},
-    {file = "pandas-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:77550c8909ebc23e56a89f91b40ad01b50c42cfbfab49b3393694a50549295ea"},
-    {file = "pandas-2.0.2.tar.gz", hash = "sha256:dd5476b6c3fe410ee95926873f377b856dbc4e81a9c605a0dc05aaccc6a7c6c6"},
+    {file = "pandas-2.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c7c9f27a4185304c7caf96dc7d91bc60bc162221152de697c98eb0b2648dd8"},
+    {file = "pandas-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f167beed68918d62bffb6ec64f2e1d8a7d297a038f86d4aed056b9493fca407f"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0"},
+    {file = "pandas-2.0.3-cp310-cp310-win32.whl", hash = "sha256:3ef285093b4fe5058eefd756100a367f27029913760773c8bf1d2d8bebe5d210"},
+    {file = "pandas-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:9ee1a69328d5c36c98d8e74db06f4ad518a1840e8ccb94a4ba86920986bb617e"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b084b91d8d66ab19f5bb3256cbd5ea661848338301940e17f4492b2ce0801fe8"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37673e3bdf1551b95bf5d4ce372b37770f9529743d2498032439371fc7b7eb26"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9cb1e14fdb546396b7e1b923ffaeeac24e4cedd14266c3497216dd4448e4f2d"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9cd88488cceb7635aebb84809d087468eb33551097d600c6dad13602029c2df"},
+    {file = "pandas-2.0.3-cp311-cp311-win32.whl", hash = "sha256:694888a81198786f0e164ee3a581df7d505024fbb1f15202fc7db88a71d84ebd"},
+    {file = "pandas-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6a21ab5c89dcbd57f78d0ae16630b090eec626360085a4148693def5452d8a6b"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4da0d45e7f34c069fe4d522359df7d23badf83abc1d1cef398895822d11061"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32fca2ee1b0d93dd71d979726b12b61faa06aeb93cf77468776287f41ff8fdc5"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:258d3624b3ae734490e4d63c430256e716f488c4fcb7c8e9bde2d3aa46c29089"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eae3dc34fa1aa7772dd3fc60270d13ced7346fcbcfee017d3132ec625e23bb0"},
+    {file = "pandas-2.0.3-cp38-cp38-win32.whl", hash = "sha256:f3421a7afb1a43f7e38e82e844e2bca9a6d793d66c1a7f9f0ff39a795bbc5e02"},
+    {file = "pandas-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:69d7f3884c95da3a31ef82b7618af5710dba95bb885ffab339aad925c3e8ce78"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5247fb1ba347c1261cbbf0fcfba4a3121fbb4029d95d9ef4dc45406620b25c8b"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81af086f4543c9d8bb128328b5d32e9986e0c84d3ee673a2ac6fb57fd14f755e"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1994c789bf12a7c5098277fb43836ce090f1073858c10f9220998ac74f37c69b"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ec591c48e29226bcbb316e0c1e9423622bc7a4eaf1ef7c3c9fa1a3981f89641"},
+    {file = "pandas-2.0.3-cp39-cp39-win32.whl", hash = "sha256:04dbdbaf2e4d46ca8da896e1805bc04eb85caa9a82e259e8eed00254d5e0c682"},
+    {file = "pandas-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:1168574b036cd8b93abc746171c9b4f1b83467438a5e45909fed645cf8692dbc"},
+    {file = "pandas-2.0.3.tar.gz", hash = "sha256:c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c"},
 ]
 
 [package.dependencies]
@@ -2189,7 +2189,7 @@ pytz = ">=2020.1"
 tzdata = ">=2022.1"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.1)", "SQLAlchemy (>=1.4.16)", "beautifulsoup4 (>=4.9.3)", "bottleneck (>=1.3.2)", "brotlipy (>=0.7.0)", "fastparquet (>=0.6.3)", "fsspec (>=2021.07.0)", "gcsfs (>=2021.07.0)", "html5lib (>=1.1)", "hypothesis (>=6.34.2)", "jinja2 (>=3.0.0)", "lxml (>=4.6.3)", "matplotlib (>=3.6.1)", "numba (>=0.53.1)", "numexpr (>=2.7.3)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pandas-gbq (>=0.15.0)", "psycopg2 (>=2.8.6)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.2)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "python-snappy (>=0.6.0)", "pyxlsb (>=1.0.8)", "qtpy (>=2.2.0)", "s3fs (>=2021.08.0)", "scipy (>=1.7.1)", "tables (>=3.6.1)", "tabulate (>=0.8.9)", "xarray (>=0.21.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)", "zstandard (>=0.15.2)"]
+all = ["PyQt5 (>=5.15.1)", "SQLAlchemy (>=1.4.16)", "beautifulsoup4 (>=4.9.3)", "bottleneck (>=1.3.2)", "brotlipy (>=0.7.0)", "fastparquet (>=0.6.3)", "fsspec (>=2021.07.0)", "gcsfs (>=2021.07.0)", "html5lib (>=1.1)", "hypothesis (>=6.34.2)", "jinja2 (>=3.0.0)", "lxml (>=4.6.3)", "matplotlib (>=3.6.1)", "numba (>=0.53.1)", "numexpr (>=2.7.3)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pandas-gbq (>=0.15.0)", "psycopg2 (>=2.8.6)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "python-snappy (>=0.6.0)", "pyxlsb (>=1.0.8)", "qtpy (>=2.2.0)", "s3fs (>=2021.08.0)", "scipy (>=1.7.1)", "tables (>=3.6.1)", "tabulate (>=0.8.9)", "xarray (>=0.21.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)", "zstandard (>=0.15.2)"]
 aws = ["s3fs (>=2021.08.0)"]
 clipboard = ["PyQt5 (>=5.15.1)", "qtpy (>=2.2.0)"]
 compression = ["brotlipy (>=0.7.0)", "python-snappy (>=0.6.0)", "zstandard (>=0.15.2)"]
@@ -2208,7 +2208,7 @@ plot = ["matplotlib (>=3.6.1)"]
 postgresql = ["SQLAlchemy (>=1.4.16)", "psycopg2 (>=2.8.6)"]
 spss = ["pyreadstat (>=1.1.2)"]
 sql-other = ["SQLAlchemy (>=1.4.16)"]
-test = ["hypothesis (>=6.34.2)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.6.3)"]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 
 description = "Library for evaluating and deploying human readable machine learning explanations."
 name = "pyreal"
-version = "0.4.2"
+version = "0.4.3"
 
 license = ""
 

--- a/pyreal/__init__.py
+++ b/pyreal/__init__.py
@@ -6,7 +6,7 @@ from pyreal.realapp.realapp import RealApp
 
 __author__ = "MIT Data To AI Lab"
 __email__ = "dailabmit@gmail.com"
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 
 __all__ = [

--- a/pyreal/explainers/example/similar_examples.py
+++ b/pyreal/explainers/example/similar_examples.py
@@ -1,8 +1,8 @@
 from sklearn.neighbors import KDTree
+from sklearn.preprocessing import StandardScaler
 
 from pyreal.explainers.example.base import ExampleBasedBase
 from pyreal.types.explanations.example_based import SimilarExampleExplanation
-from sklearn.preprocessing import StandardScaler
 
 
 class SimilarExamples(ExampleBasedBase):

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -731,6 +731,8 @@ class RealApp:
             The dataframe to use (x_orig or self.x_train_orig), may be None if neither is given
         """
         if x_train_orig is not None:
+            if self.id_column is not None and self.id_column in x_train_orig:
+                return x_train_orig.drop(columns=self.id_column)
             return x_train_orig
         else:
             return self.X_train_orig

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -634,6 +634,7 @@ class RealApp:
         model_id=None,
         algorithm=None,
         training_size=None,
+        standardize=False,
     ):
         """
         Initialize and fit a nearest neighbor explainer
@@ -649,6 +650,9 @@ class RealApp:
                 NN algorithm to use (current options: [nn])
             training_size (int):
                 Number of rows to use in fitting explainer
+            standardize (Boolean):
+                If True, standardize data before using it to get similar examples.
+                Recommended if model-ready data is not already standardized
 
         Returns:
             A fit SimilarExamples explainer
@@ -667,6 +671,7 @@ class RealApp:
             classes=self.classes,
             class_descriptions=self.class_descriptions,
             training_size=training_size,
+            standardize=standardize
         )
         explainer.fit(self._get_x_train_orig(x_train_orig), self._get_y_train(y_train))
         self._add_explainer("se", algorithm, explainer)
@@ -679,6 +684,7 @@ class RealApp:
         x_train_orig=None,
         y_train=None,
         n=3,
+        standardize=False,
         algorithm=None,
         force_refit=False,
     ):
@@ -696,6 +702,9 @@ class RealApp:
                 Training targets to fit on, if not provided during initialization
             n (int):
                 Number of similar examples to return
+            standardize (Boolean):
+                If True, standardize data before using it to get similar examples.
+                Recommended if model-ready data is not already standardized
             algorithm (string):
                 Name of algorithm
             force_refit (Boolean):
@@ -718,6 +727,7 @@ class RealApp:
             x_train_orig=x_train_orig,
             y_train=y_train,
             force_refit=force_refit,
+            prepare_kwargs={"standardize": standardize},
             produce_kwargs={"n": n},
         )
 

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -671,7 +671,7 @@ class RealApp:
             classes=self.classes,
             class_descriptions=self.class_descriptions,
             training_size=training_size,
-            standardize=standardize
+            standardize=standardize,
         )
         explainer.fit(self._get_x_train_orig(x_train_orig), self._get_y_train(y_train))
         self._add_explainer("se", algorithm, explainer)

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -428,9 +428,9 @@ class RealApp:
 
     def prepare_feature_contributions(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         shap_type=None,
         training_size=None,
@@ -531,9 +531,9 @@ class RealApp:
 
     def prepare_feature_importance(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         shap_type=None,
         training_size=None,
@@ -629,9 +629,9 @@ class RealApp:
 
     def prepare_similar_examples(
         self,
-        model_id=None,
         x_train_orig=None,
         y_train=None,
+        model_id=None,
         algorithm=None,
         training_size=None,
     ):

--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -203,6 +203,19 @@ class Transformer(ABC):
         self.fit(x, **fit_params)
         return self.data_transform(x)
 
+    def inverse_transform(self, x_new):
+        """
+        Transforms data `x_new` from new feature space back into the original feature space.
+        Args:
+            x_new (DataFrame of shape (n_instances, n_transformed_features)):
+                The dataset to inverse-transform
+
+        Returns:
+            DataFrame of shape (n_instances, n_features):
+                The inverse-transformed dataset
+        """
+        raise NotImplementedError("Inverse transform is not defined for this Transformer.")
+
     def inverse_transform_explanation(self, explanation):
         """
         Transforms the explanation from the second feature space handled by this transformer

--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -202,7 +202,7 @@ class Transformer(ABC):
         """
         self.fit(x, **fit_params)
         return self.data_transform(x)
-    
+
     def inverse_data_transform(self, x_new):
         """
         Wrapper for inverse_data_transform.
@@ -215,7 +215,6 @@ class Transformer(ABC):
             DataFrame of shape (n_instances, n_features):
                 The inverse-transformed dataset
         """
-        return self.
         raise NotImplementedError("Inverse transform is not defined for this Transformer.")
 
     def inverse_transform(self, x_new):
@@ -229,7 +228,7 @@ class Transformer(ABC):
             DataFrame of shape (n_instances, n_features):
                 The inverse-transformed dataset
         """
-        raise NotImplementedError("Inverse transform is not defined for this Transformer.")
+        return self.inverse_data_transform(x_new)
 
     def inverse_transform_explanation(self, explanation):
         """

--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -202,6 +202,21 @@ class Transformer(ABC):
         """
         self.fit(x, **fit_params)
         return self.data_transform(x)
+    
+    def inverse_data_transform(self, x_new):
+        """
+        Wrapper for inverse_data_transform.
+        Transforms data `x_new` from new feature space back into the original feature space.
+        Args:
+            x_new (DataFrame of shape (n_instances, n_transformed_features)):
+                The dataset to inverse-transform
+
+        Returns:
+            DataFrame of shape (n_instances, n_features):
+                The inverse-transformed dataset
+        """
+        return self.
+        raise NotImplementedError("Inverse transform is not defined for this Transformer.")
 
     def inverse_transform(self, x_new):
         """

--- a/pyreal/transformers/one_hot_encode.py
+++ b/pyreal/transformers/one_hot_encode.py
@@ -159,7 +159,7 @@ class OneHotEncoder(Transformer):
         x_cat_ohe = pd.DataFrame(x_cat_ohe, columns=self.onehot_columns, index=index)
         return pd.concat([x.drop(self.columns, axis="columns"), x_cat_ohe], axis=1)
 
-    def inverse_transform(self, x_new):
+    def inverse_data_transform(self, x_new):
         """
         Transforms one-hot encoded data `x_new` back into the original feature space.
         Args:
@@ -347,7 +347,7 @@ class MappingsOneHotEncoder(Transformer):
                     ohe_data[ohe_feature][np.where(values == ohe_feature_dict[ohe_feature])] = True
         return pd.DataFrame(ohe_data)
 
-    def inverse_transform(self, x_onehot):
+    def inverse_data_transform(self, x_onehot):
         """
         Transforms one-hot encoded data `x_onehot` back into categorical form.
         Args:
@@ -432,7 +432,7 @@ class MappingsOneHotDecoder(Transformer):
                 ][1]
         return pd.DataFrame(cat_data)
 
-    def inverse_transform(self, x_cat):
+    def inverse_data_transform(self, x_cat):
         """
         Transforms one-hot decoded data `x_cat` back into one-hot encoded form.
         Args:

--- a/pyreal/transformers/wrappers.py
+++ b/pyreal/transformers/wrappers.py
@@ -49,7 +49,7 @@ class DataFrameWrapper(Transformer):
         transformed_np = self.wrapped_transformer.transform(x)
         return pd.DataFrame(transformed_np, columns=x.columns, index=x.index)
 
-    def inverse_transform(self, x_new):
+    def inverse_data_transform(self, x_new):
         """
         Inverese transform `x_new` using the wrapped transformer
         Args:

--- a/pyreal/transformers/wrappers.py
+++ b/pyreal/transformers/wrappers.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from pyreal.transformers import Transformer
@@ -47,3 +48,20 @@ class DataFrameWrapper(Transformer):
         """
         transformed_np = self.wrapped_transformer.transform(x)
         return pd.DataFrame(transformed_np, columns=x.columns, index=x.index)
+
+    def inverse_transform(self, x_new):
+        """
+        Inverese transform `x_new` using the wrapped transformer
+        Args:
+            x_new (DataFrame of shape (n_instances, n_transformed_features)):
+                The dataset to inverse transform
+
+        Returns:
+            DataFrame of shape (n_instances, n_features):
+                The dataset after inverse transform
+        """
+        inv_transformed_data = self.wrapped_transformer.inverse_transform(x_new)
+        if isinstance(inv_transformed_data, np.ndarray):
+            return pd.DataFrame(inv_transformed_data, columns=x_new.columns, index=x_new.index)
+        else:
+            return inv_transformed_data

--- a/tests/explainers/example/test_similar_examples.py
+++ b/tests/explainers/example/test_similar_examples.py
@@ -5,13 +5,13 @@ from pyreal.explainers.example.similar_examples import SimilarExamples
 
 
 def test_produce(dummy_model):
-    X = pd.DataFrame([[1, 1, 1], [4, 5, 3], [0, 0, 0], [5, 5, 3]])
+    x = pd.DataFrame([[1, 1, 1], [4, 5, 3], [0, 0, 0], [5, 5, 3]])
     y = pd.Series([0, 1, 0, 1])
 
-    explainer = SimilarExamples(model=dummy_model, x_train_orig=X, y_train=y, fit_on_init=True)
+    explainer = SimilarExamples(model=dummy_model, x_train_orig=x, y_train=y, fit_on_init=True)
     result = explainer.produce(pd.DataFrame([[0, 1, 0]]), n=2)
-    expected_examples = pd.DataFrame([[0, 0, 0], [1, 1, 1]])
-    expected_targets = pd.Series([0, 0])
+    expected_examples = x.iloc[[2, 0], :]
+    expected_targets = y.iloc[[2, 0]]
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 2
     assert_frame_equal(result.get_examples(), expected_examples)

--- a/tests/explainers/example/test_similar_examples.py
+++ b/tests/explainers/example/test_similar_examples.py
@@ -14,8 +14,8 @@ def test_produce(dummy_model):
     expected_targets = pd.Series([0, 0])
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 2
-    assert_frame_equal(result.get_examples().reset_index(drop=True), expected_examples)
-    assert_series_equal(result.get_targets().reset_index(drop=True), expected_targets)
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)
 
 
 def test_produce_with_transforms(regression_one_hot_with_interpret):
@@ -35,10 +35,8 @@ def test_produce_with_transforms(regression_one_hot_with_interpret):
 
     assert len(result.get_row_ids()) == 1
     assert result.get_examples(row_id=0).shape[0] == 1
-    assert_frame_equal(result.get_examples().reset_index(drop=True), expected_examples)
-    print(result.get_targets())
-    print(expected_targets)
-    assert_series_equal(result.get_targets().reset_index(drop=True), expected_targets)
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)
 
 
 def test_produce_multiple_with_transforms(regression_one_hot_with_interpret):
@@ -68,3 +66,24 @@ def test_produce_multiple_with_transforms(regression_one_hot_with_interpret):
     assert result.get_examples(row_id=1).shape[0] == 2
     assert_frame_equal(result.get_examples(row_id=1), expected_examples_2)
     assert_series_equal(result.get_targets(row_id=1), expected_targets_2)
+
+
+def test_produce_with_standardize(dummy_model):
+    x = pd.DataFrame([[1, 100], [3, 100], [1, 200], [3, 300]])
+    y = pd.Series([1, 2, 3, 4])
+    explainer = SimilarExamples(
+        model=dummy_model,
+        x_train_orig=x,
+        y_train=y,
+        fit_on_init=True,
+        standardize=True,
+    )
+    result = explainer.produce(pd.DataFrame([[1, 100]]), n=2)
+    expected_examples = x.iloc[[0, 2], :]
+    expected_targets = y.iloc[[0, 2]]
+
+    assert len(result.get_row_ids()) == 1
+    assert result.get_examples(row_id=0).shape[0] == 2
+
+    assert_frame_equal(result.get_examples(), expected_examples)
+    assert_series_equal(result.get_targets(), expected_targets)

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,5 +1,6 @@
-from pyreal import RealApp
 import pytest
+
+from pyreal import RealApp
 
 
 def test_prepare_global_feature_importance(regression_no_transforms):
@@ -12,8 +13,9 @@ def test_prepare_global_feature_importance(regression_no_transforms):
         realApp.produce_feature_importance()
 
     # Confirm no error
-    realApp.prepare_feature_importance(x_train_orig=regression_no_transforms["x"],
-                                       y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_importance(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_importance()

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,4 +1,22 @@
 from pyreal import RealApp
+import pytest
+
+
+def test_prepare_global_feature_importance(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+
+    with pytest.raises(ValueError):
+        realApp.produce_feature_importance()
+
+    # Confirm no error
+    realApp.prepare_feature_importance(x_train_orig=regression_no_transforms["x"],
+                                       y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_importance()
 
 
 def test_produce_global_feature_importance(regression_no_transforms):

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,5 +1,7 @@
-from pyreal import RealApp
+import pandas as pd
 import pytest
+
+from pyreal import RealApp
 
 
 def test_prepare_global_feature_importance(regression_no_transforms):
@@ -12,8 +14,27 @@ def test_prepare_global_feature_importance(regression_no_transforms):
         realApp.produce_feature_importance()
 
     # Confirm no error
-    realApp.prepare_feature_importance(x_train_orig=regression_no_transforms["x"],
-                                       y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_importance(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_importance()
+
+
+def test_prepare_global_feature_importance_with_id_column(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+        id_column="ID",
+    )
+    features = ["A", "B", "C"]
+    x_multi_dim = pd.DataFrame([[4, 1, 1, "a"], [6, 2, 3, "b"]], columns=features + ["ID"])
+
+    # Confirm no error
+    realApp.prepare_feature_importance(
+        x_train_orig=x_multi_dim, y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_importance()

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -37,8 +37,9 @@ def test_prepare_local_feature_contribution(regression_no_transforms):
         realApp.produce_feature_contributions(x)
 
     # Confirm no error
-    realApp.prepare_feature_contributions(x_train_orig=regression_no_transforms["x"],
-                                          y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_contributions(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_contributions(x)

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from pyreal import RealApp
 from pyreal.realapp.realapp import _get_average_or_mode
@@ -23,6 +24,24 @@ def test_average_or_mode():
     result = _get_average_or_mode(mean_only)
     for i in range(len(expected)):
         assert expected[i] == result[i]
+
+
+def test_prepare_local_feature_contribution(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+    x = pd.DataFrame([[2, 10, 10]])
+
+    with pytest.raises(ValueError):
+        realApp.produce_feature_contributions(x)
+
+    # Confirm no error
+    realApp.prepare_feature_contributions(x_train_orig=regression_no_transforms["x"],
+                                          y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_contributions(x)
 
 
 def test_produce_local_feature_contributions(regression_no_transforms):

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -37,11 +37,30 @@ def test_prepare_local_feature_contribution(regression_no_transforms):
         realApp.produce_feature_contributions(x)
 
     # Confirm no error
-    realApp.prepare_feature_contributions(x_train_orig=regression_no_transforms["x"],
-                                          y_train=regression_no_transforms["y"])
+    realApp.prepare_feature_contributions(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_feature_contributions(x)
+
+
+def test_prepare_local_feature_contribution_with_id_column(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+        id_column="ID",
+    )
+    features = ["A", "B", "C"]
+    x_multi_dim = pd.DataFrame([[4, 1, 1, "a"], [6, 2, 3, "b"]], columns=features + ["ID"])
+
+    # Confirm no error
+    realApp.prepare_feature_contributions(
+        x_train_orig=x_multi_dim, y_train=regression_no_transforms["y"]
+    )
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_feature_contributions(x_multi_dim)
 
 
 def test_produce_local_feature_contributions(regression_no_transforms):
@@ -86,8 +105,6 @@ def test_produce_local_feature_contributions_with_id_column(regression_one_hot):
 
     features = ["A", "B", "C"]
     x_multi_dim = pd.DataFrame([[4, 1, 1, "a"], [6, 2, 3, "b"]], columns=features + ["ID"])
-
-    real_app.prepare_feature_contributions(x_multi_dim)
 
     explanation = real_app.produce_feature_contributions(x_multi_dim)
 

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -58,16 +58,19 @@ def test_produce_local_feature_contributions(regression_no_transforms):
 
 
 def test_produce_local_feature_contributions_with_id_column(regression_one_hot):
-    realApp = RealApp(
+    real_app = RealApp(
         regression_one_hot["model"],
         regression_one_hot["x"],
         transformers=regression_one_hot["transformers"],
         id_column="ID",
     )
-    features = ["A", "B", "C"]
 
+    features = ["A", "B", "C"]
     x_multi_dim = pd.DataFrame([[4, 1, 1, "a"], [6, 2, 3, "b"]], columns=features + ["ID"])
-    explanation = realApp.produce_feature_contributions(x_multi_dim)
+
+    real_app.prepare_feature_contributions(x_multi_dim)
+
+    explanation = real_app.produce_feature_contributions(x_multi_dim)
 
     explanation_a = explanation["a"].sort_values(by="Feature Name", axis=0)
     explanation_b = explanation["b"].sort_values(by="Feature Name", axis=0)

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
 import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pyreal import RealApp
 
@@ -39,10 +39,27 @@ def test_prepare_similar_examples(regression_no_transforms):
         realApp.produce_similar_examples(x)
 
     # Confirm no error
-    realApp.prepare_similar_examples(x_train_orig=regression_no_transforms["x"],
-                                     y_train=regression_no_transforms["y"])
+    realApp.prepare_similar_examples(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_similar_examples(x)
 
 
+def test_prepare_similar_examples_with_id_column(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+        id_column="ID",
+    )
+    features = ["A", "B", "C"]
+    x_multi_dim = pd.DataFrame(
+        [[4, 1, 1, "a"], [6, 2, 3, "b"], [1, 1, 1, "c"]], columns=features + ["ID"]
+    )
+
+    # Confirm no error
+    realApp.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_similar_examples(x_multi_dim, n=1)

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -8,7 +8,7 @@ from pyreal import RealApp
 def test_produce_similar_examples(regression_one_hot_with_interpret):
     x = pd.DataFrame([[2, 0, 0], [6, 6, 6], [6, 7, 8], [2, 0, 1]], columns=["A", "B", "C"])
     y = pd.Series([1, 0, 0, 1])
-    realApp = RealApp(
+    real_app = RealApp(
         regression_one_hot_with_interpret["model"],
         X_train_orig=x,
         y_train=y,
@@ -16,7 +16,7 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
         id_column="ID",
     )
 
-    explanation = realApp.produce_similar_examples(
+    explanation = real_app.produce_similar_examples(
         pd.DataFrame([["id1", 6, 7, 9], ["id2", 2, 1, 1]], columns=["ID", "A", "B", "C"]), n=2
     )
     assert "id1" in explanation
@@ -29,26 +29,26 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
 
 
 def test_prepare_similar_examples(regression_no_transforms):
-    realApp = RealApp(
+    real_app = RealApp(
         regression_no_transforms["model"],
         transformers=regression_no_transforms["transformers"],
     )
     x = pd.DataFrame([[2, 10, 10]])
 
     with pytest.raises(ValueError):
-        realApp.produce_similar_examples(x)
+        real_app.produce_similar_examples(x)
 
     # Confirm no error
-    realApp.prepare_similar_examples(
+    real_app.prepare_similar_examples(
         x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
     )
 
     # Confirm explainer was prepped and now works without being given data
-    realApp.produce_similar_examples(x)
+    real_app.produce_similar_examples(x)
 
 
 def test_prepare_similar_examples_with_id_column(regression_no_transforms):
-    realApp = RealApp(
+    real_app = RealApp(
         regression_no_transforms["model"],
         transformers=regression_no_transforms["transformers"],
         id_column="ID",
@@ -59,7 +59,22 @@ def test_prepare_similar_examples_with_id_column(regression_no_transforms):
     )
 
     # Confirm no error
-    realApp.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
+    real_app.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
 
     # Confirm explainer was prepped and now works without being given data
-    realApp.produce_similar_examples(x_multi_dim, n=1)
+    real_app.produce_similar_examples(x_multi_dim, n=1)
+
+
+def test_produce_similar_examples_with_standardization(dummy_model):
+    x = pd.DataFrame([[1, 100], [3, 100], [1, 200], [3, 300]])
+    y = pd.Series([1, 2, 3, 4])
+    real_app = RealApp(
+        dummy_model,
+        X_train_orig=x,
+        y_train=y,
+    )
+
+    explanation = real_app.produce_similar_examples(pd.DataFrame([[1, 100]]), n=2, standardize=True)
+
+    assert_frame_equal(explanation[0]["X"], x.iloc[[0, 2], :])
+    assert_series_equal(explanation[0]["y"], y.iloc[[0, 2]])

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
 import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pyreal import RealApp
 
@@ -39,10 +39,9 @@ def test_prepare_similar_examples(regression_no_transforms):
         realApp.produce_similar_examples(x)
 
     # Confirm no error
-    realApp.prepare_similar_examples(x_train_orig=regression_no_transforms["x"],
-                                     y_train=regression_no_transforms["y"])
+    realApp.prepare_similar_examples(
+        x_train_orig=regression_no_transforms["x"], y_train=regression_no_transforms["y"]
+    )
 
     # Confirm explainer was prepped and now works without being given data
     realApp.produce_similar_examples(x)
-
-

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -74,7 +74,9 @@ def test_produce_similar_examples_with_standardization(dummy_model):
         y_train=y,
     )
 
-    explanation = real_app.produce_similar_examples(pd.DataFrame([[1, 100]]), n=2, standardize=True)
+    explanation = real_app.produce_similar_examples(
+        pd.DataFrame([[1, 100]]), n=2, standardize=True
+    )
 
     assert_frame_equal(explanation[0]["X"], x.iloc[[0, 2], :])
     assert_series_equal(explanation[0]["y"], y.iloc[[0, 2]])

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
+import pytest
 
 from pyreal import RealApp
 
@@ -25,3 +26,23 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
     assert "id2" in explanation
     assert_frame_equal(explanation["id2"]["X"], x.iloc[[3, 0], :] + 1)
     assert_series_equal(explanation["id2"]["y"], y.iloc[[3, 0]])
+
+
+def test_prepare_similar_examples(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        transformers=regression_no_transforms["transformers"],
+    )
+    x = pd.DataFrame([[2, 10, 10]])
+
+    with pytest.raises(ValueError):
+        realApp.produce_similar_examples(x)
+
+    # Confirm no error
+    realApp.prepare_similar_examples(x_train_orig=regression_no_transforms["x"],
+                                     y_train=regression_no_transforms["y"])
+
+    # Confirm explainer was prepped and now works without being given data
+    realApp.produce_similar_examples(x)
+
+

--- a/tests/transformers/test_one_hot_encode.py
+++ b/tests/transformers/test_one_hot_encode.py
@@ -60,6 +60,15 @@ def test_transform_all_columns_one_hot_encoder(transformer_test_data):
     assert_frame_equal(transformed_x, expected_transformed_x, check_dtype=False)
 
 
+def test_inverse_transform_one_hot_encoder(transformer_test_data):
+    ohe_transformer = OneHotEncoder(columns=transformer_test_data["columns"])
+    ohe_transformer.fit(transformer_test_data["x"])
+    test_x = pd.DataFrame([[6, 0, 2, 1], [4, 1, 3, 8], [2, 0, 4, 3]], columns=["A", "B", "C", "D"])
+    transformed_x = ohe_transformer.transform(test_x)
+    identity_x = ohe_transformer.inverse_transform(transformed_x)
+    assert_frame_equal(identity_x, test_x, check_dtype=False)
+
+
 categorical_to_one_hot = {
     "A": {"A_a": "a", "A_b": "b"},
     "B": {"B_a": "a", "B_b": "b", "B_c": "c"},
@@ -109,9 +118,26 @@ def test_mappings_encode_decode(mappings):
     assert_frame_equal(x_decoded, x)
 
 
+@pytest.mark.parametrize("mappings", mappings_choices)
+def test_mappings_inverse_transform(mappings):
+    mappings_ohe = MappingsOneHotEncoder(mappings)
+
+    x = pd.DataFrame([["a", "b", 10, "f"], ["b", "c", 11, "d"]], columns=["A", "B", "C", "D"])
+    x_encoded = mappings_ohe.transform(x)
+    x_identity = mappings_ohe.inverse_transform(x_encoded)
+    assert_frame_equal(x_identity, x)
+
+    mappings_ohd = MappingsOneHotDecoder(mappings)
+    x_encoded_identity = mappings_ohd.inverse_transform(x)
+
+    assert_frame_equal(x_encoded_identity, x_encoded)
+
+
 def test_fit_returns_self():
-    for transformer in [MappingsOneHotDecoder(mappings_ctoh),
-                        MappingsOneHotEncoder(mappings_ctoh),
-                        OneHotEncoder(columns=[])]:
+    for transformer in [
+        MappingsOneHotDecoder(mappings_ctoh),
+        MappingsOneHotEncoder(mappings_ctoh),
+        OneHotEncoder(columns=[]),
+    ]:
         result = transformer.fit(pd.DataFrame([0, 1]))
         assert result == transformer


### PR DESCRIPTION
## Release v.0.4.3
Small improvements and bugfixes

### New Features 
- Similar Examples explainers can now optionally standardize the data right before getting neighbors (#421)
- Some transformers now support inverse data transforming (#405)

### Bug fixes
- Fixing bug with realapp objects where prepare would not use the given ID column (#418)

### Other changes
- Some libraries have had versions updated (#422, #423)
