### PR TITLE
scale transformers

### DIFF
--- a/pyreal/transformers/__init__.py
+++ b/pyreal/transformers/__init__.py
@@ -30,6 +30,7 @@ from pyreal.transformers.time_series_formatter import (
 from pyreal.transformers.wrappers import DataFrameWrapper
 from pyreal.transformers.pad import TimeSeriesPadder
 from pyreal.transformers.type_cast import BoolToIntCaster
+from pyreal.transformers.scale import MinMaxScaler
 
 __all__ = [
     "Transformer",
@@ -59,4 +60,5 @@ __all__ = [
     "Pandas2dToMultiIndexFrame",
     "TimeSeriesPadder",
     "BoolToIntCaster",
+    "MinMaxScaler",
 ]

--- a/pyreal/transformers/scale.py
+++ b/pyreal/transformers/scale.py
@@ -1,0 +1,112 @@
+import sklearn
+from sklearn.preprocessing import MinMaxScaler as SklearnMinMaxScaler
+from sklearn.preprocessing import Normalizer as SklearnNormalizer
+from sklearn.preprocessing import StandardScaler as SklearnStandardScaler
+
+from pyreal.transformers import Transformer
+from pyreal.transformers.wrappers import DataFrameWrapper
+
+
+class MinMaxScaler:
+    """
+    basically a sklearn MinMaxScaler but maintains DataFrame type
+    """
+
+    def __init__(self, feature_range=(0, 1), *, copy=True, clip=False):
+        """initialize a wrapped transformer, then make a DataFrameWrapper for it, then wrap the DataFrameWrapper
+
+        Args:
+            feature_range (tuple (min, max), default=(0, 1)): Desired range of transformed data.
+            copy (bool, default=True): Set to False to perform inplace row normalization and avoid a copy (if the input is already a numpy array).
+            clip (bool, default=False): Set to True to clip transformed values of held-out data to provided feature range.
+        """
+        self.data_frame_wrapper = DataFrameWrapper(
+            SklearnMinMaxScaler(feature_range, copy=copy, clip=clip)
+        )
+        # self.sklearn = self.data_frame_wrapper.wrapped_transformer
+
+        # attributes
+        self.min_ = None
+        self.scale_ = None
+        self.data_min_ = None
+        self.data_max_ = None
+        self.data_range_ = None
+        self.n_features_in_ = None
+        self.n_samples_seen_ = None
+        self.feature_names_in_ = None
+
+    # methods
+
+    def fit(self, X, y=None):
+        # computes per-feature min & max (self.data_min_, self.data_max_)
+        ret = self.data_frame_wrapper.fit(X, y=y)
+        self.min_ = self.data_frame_wrapper.wrapped_transformer.min_
+        self.data_min_ = self.data_frame_wrapper.wrapped_transformer.data_min_
+        self.data_max_ = self.data_frame_wrapper.wrapped_transformer.data_max_
+        self.data_range_ = self.data_frame_wrapper.wrapped_transformer.data_range_
+        return ret
+
+    def fit_transform(self, X, y=None, **fit_params):
+        return self.data_frame_wrapper.fit_transform(X, y, **fit_params)
+
+    def inverse_transform(self, X):
+        return self.data_frame_wrapper.inverse_transform(X)
+
+    def data_transform(self, X):
+        return self.data_frame_wrapper.transform(X)
+
+
+class Normalizer:
+    def __init__(self, norm="l2", *, copy=True):
+        """_summary_
+
+        Args:
+            norm (str, optional): The norm to use to normalize each non zero sample.
+                                  If norm=’max’ is used, values will be rescaled by the maximum of the absolute values.
+                                  Can take values {‘l1’, ‘l2’, ‘max’}. Defaults to 'l2'.
+            copy (bool, optional): Set to False to perform inplace row normalization and avoid a copy
+                                   (if the input is already a numpy array or a scipy.sparse CSR matrix). Defaults to True.
+        """
+        self.data_frame_wrapper = DataFrameWrapper(SklearnNormalizer(norm, copy=copy))
+
+    # write methods
+    def fit(self, X, y=None):
+        return self.data_frame_wrapper.fit(X, y=y)
+
+    def fit_transform(self, X, y=None, **fit_params):
+        return self.data_frame_wrapper.fit_transform(X, y, **fit_params)
+
+    def data_transform(self, X):
+        return self.data_frame_wrapper.transform(X)
+
+
+class StandardScaler(Transformer):
+    def __init__(self, *, copy=True, with_mean=True, with_std=True):
+        """creates a pyreal StandardScaler
+
+        Args:
+            copy (bool, optional): If False, try to avoid a copy and do inplace scaling instead.
+                                   This is not guaranteed to always work inplace;
+                                   e.g. if the data is not a NumPy array or scipy.sparse CSR matrix, a copy may still be returned.
+            with_mean (bool, optional): If True, center the data before scaling.
+                                        This does not work (and will raise an exception) when attempted on sparse matrices,
+                                        because centering them entails building a dense matrix which in common use cases is likely to be too large to fit in memory.
+            with_std (bool, optional): If True, scale the data to unit variance (or equivalently, unit standard deviation).
+        """
+        self.data_frame_wrapper = DataFrameWrapper(
+            SklearnStandardScaler(copy=copy, with_mean=with_mean, with_std=with_std)
+        )
+        self.mean_ = None
+        self.var_ = None
+
+    def fit(self, X, y=None, sample_weight=None):
+        ret = self.data_frame_wrapper.fit(X, y=y, sample_weight=sample_weight)
+        self.mean_ = ret.wrapped_transformer.mean_
+        self.var_ = ret.wrapped_transformer.var_
+        return ret
+
+    def data_transform(self, X):
+        return self.data_frame_wrapper.transform(X)
+
+    def inverse_transform(self, X):
+        return self.data_frame_wrapper.inverse_transform(X)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,3 +195,8 @@ def time_series_data():
     for v in range(n_var):
         nested[f"var_{v}"] = [pd.Series(np3d[i, v, :]) for i in range(n_inst)]
     return {"np3d": np3d, "np2d": np2d, "df3d": df3d, "df2d": df2d, "nested": nested}
+
+@pytest.fixture()
+def minmax_scale_data():
+    x = [[2, 1, 3, 9], [4, 3, 4, 0], [6, 7, 2, 2]]
+    return x

--- a/tests/transformers/test_scale.py
+++ b/tests/transformers/test_scale.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
+from sklearn.preprocessing import MinMaxScaler as SklearnMinMaxScaler
+from sklearn.preprocessing import Normalizer as SklearnNormalizer
+from sklearn.preprocessing import StandardScaler as SklearnStandardScaler
+
+from pyreal.transformers.scale import MinMaxScaler, Normalizer, StandardScaler
+from pyreal.transformers.wrappers import DataFrameWrapper
+
+# MinMaxScaler tests
+data = [[2, 1, 3, 10], [4, 3, 4, 0], [6, 7, 2, 2]]
+columns = ["A", "B", "C", "D"]
+
+# tests!!! they all test whether the MinMaxScaler behaves the same as the SklearnMinMaxScaler
+
+
+def test_fit_minmax():
+    skMinMax = SklearnMinMaxScaler()
+    skMinMax.fit(data)
+
+    pdData = DataFrame(data)
+    minmax = MinMaxScaler()
+    minmax.fit(pdData)
+
+    # our scaler objects are different types; test the attributes
+    assert all(
+        [skMinMax.data_min_[i] == minmax.data_min_[i] for i in range(len(skMinMax.data_min_))]
+    )
+    assert all(
+        [skMinMax.data_max_[i] == minmax.data_max_[i] for i in range(len(skMinMax.data_max_))]
+    )
+    assert all(
+        [
+            skMinMax.data_range_[i] == minmax.data_range_[i]
+            for i in range(len(skMinMax.data_range_))
+        ]
+    )
+    assert all([skMinMax.min_[i] == minmax.min_[i] for i in range(len(skMinMax.min_))])
+
+
+def test_inverse_transform_minmax():
+    sklearnScaler = SklearnMinMaxScaler()
+    sklearnScaler.fit(data)
+    sk = sklearnScaler.inverse_transform(data)
+
+    pdData = DataFrame(data)
+    minmax = MinMaxScaler()
+    minmax.fit(pdData)
+    mm = minmax.inverse_transform(pdData)
+
+    for i in range(len(sk)):
+        assert all([sk[i][j] == mm.values[i][j] for j in range(len(sk[i]))])
+
+
+def test_transform_minmax():
+    skMinMax = SklearnMinMaxScaler()
+    skMinMax.fit(data)
+    sk = skMinMax.transform(data)
+
+    pdData = DataFrame(data)
+    minmax = MinMaxScaler()
+    minmax.fit(pdData)
+    mm = minmax.data_transform(pdData)
+    for j in range(len(sk)):
+        assert all([sk[j][i] == mm.values[j][i] for i in range(len(sk[0]))])
+
+
+# NORMALIZER TESTS
+
+
+def test_fit_normalizer():
+    norm = Normalizer()
+    pdData = DataFrame(data)
+    norm.fit(pdData)
+    # if nothing happens, it passes
+
+
+def test_transform_normalizer():
+    skNormal = SklearnNormalizer()
+    skNormal.fit(data)
+    sk = skNormal.transform(data)
+
+    pdData = DataFrame(data)
+    normal = Normalizer()
+    normal.fit(pdData)
+    norm = normal.data_transform(pdData)
+
+    for i in range(len(data)):
+        assert (sk[i][j] == norm.values[i][j] for j in range(len(data[i])))
+
+
+# STANDARD SCALER
+
+
+def test_fit_standardscale():
+    skStandard = SklearnStandardScaler()
+    skStandard.fit(data)
+
+    pdData = DataFrame(data)
+    standard = StandardScaler()
+    standard.fit(data)
+
+    assert (skStandard.mean_[i] == standard.mean_[i] for i in range(len(skStandard.mean_)))
+    assert (skStandard.var_[i] == standard.var_[i] for i in range(len(skStandard.var_)))
+
+
+def test_transform_standardscale():
+    skStandard = SklearnStandardScaler()
+    skStandard.fit(data)
+    sk = skStandard.transform(data)
+
+    pdData = DataFrame(data)
+    standard = StandardScaler()
+    standard.fit(pdData)
+    std = standard.data_transform(pdData)
+
+    for i in range(len(data)):
+        assert (sk[i][j] == std.values[i][j] for j in range(len(data[i])))
+
+
+def test_inverse_transform_standardscale():
+    sklearnScaler = SklearnStandardScaler()
+    sklearnScaler.fit(data)
+    sk = sklearnScaler.inverse_transform(data)
+
+    pdData = DataFrame(data)
+    minmax = StandardScaler()
+    minmax.fit(pdData)
+    mm = minmax.inverse_transform(pdData)
+
+    for i in range(len(sk)):
+        assert all([sk[i][j] == mm.values[i][j] for j in range(len(sk[i]))])
+
+
+if __name__ == "__main__":
+    test_fit_standardscale()


### PR DESCRIPTION
### Closing issues

Closes #432

### Description

Describe what problem this PR solves and what changes it makes. Include an explanation of any design decisions you made.

This PR directly implements the MinMaxScaler, Normalizer, and StandardScaler sklearn transformers into Pyreal. It involves wrapping a DataFrameWrapper which itself wraps the transformer in question. They all implement fit, data_transform, and inverse_transform (if applicable).

### Test Plan

The tests for this PR are in scale.py, and test whether the behavior of the Pyreal-implemented scalers have the same behavior as their sklearn counterparts.

