### PR TITLE
add predict_proba function to realapp and explainer object

### DIFF
--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -417,6 +417,25 @@ class ExplainerBase(ABC):
         x_model = self.transform_to_x_model(x_orig)
         return self.model.predict(x_model)
 
+    def model_predict_proba(self, x_orig):
+        """
+        Return the output probabilities of each class for x_orig
+
+        Args:
+            x_orig (DataFrame of shape (n_instances, x_orig_feature_count)):
+                Data to predict on
+
+        Returns:
+            DataFrame of shape (n_instances, n_classes)
+                Model output probabilities on x_orig
+        """
+        if not hasattr(self.model, "predict_proba"):
+            raise AttributeError("Model does not have a predict_proba method.")
+        if x_orig.ndim == 1:
+            x_orig = x_orig.to_frame().T
+        x_model = self.transform_to_x_model(x_orig)
+        return self.model.predict_proba(x_model)
+
     def model_predict_on_algorithm(self, x_algorithm):
         """
         Predict on x_algorithm using the model and return the result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def classification_no_transforms(test_root):
     y = pd.Series([1, 1, 3])
     model_no_transforms = LogisticRegression()
     model_no_transforms.fit(x, pd.Series([1, 2, 3]))
-    model_no_transforms.coef_ = np.array([[0, 1, 0], [0, 1, 0], [0, 0, 1]])
+    model_no_transforms.coef_ = np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     model_no_transforms.intercept_ = np.array([0])
     model_no_transforms_filename = os.path.join(test_root, "data", "model_no_transforms.pkl")
     with open(model_no_transforms_filename, "wb") as f:
@@ -106,6 +106,7 @@ def classification_no_transforms(test_root):
         "x": x,
         "y": y,
         "classes": np.arange(1, 4),
+        "coefs": model_no_transforms.coef_,
     }
 
 
@@ -115,7 +116,7 @@ def binary_classification_no_transforms(test_root):
     y = pd.Series([1, 1, 0])
     model_no_transforms = LogisticRegression()
     model_no_transforms.fit(x, pd.Series([1, 2, 3]))
-    model_no_transforms.coef_ = np.array([[0, 1, 0], [0, 1, 0], [0, 0, 1]])
+    model_no_transforms.coef_ = np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     model_no_transforms.intercept_ = np.array([0])
     model_no_transforms_filename = os.path.join(test_root, "data", "model_no_transforms.pkl")
     with open(model_no_transforms_filename, "wb") as f:

--- a/tests/realapp/test_realapp.py
+++ b/tests/realapp/test_realapp.py
@@ -104,10 +104,10 @@ def test_predict_proba(classification_no_transforms):
 
     result = real_app.predict_proba(classification_no_transforms["x"])
     for key in result.keys():
-        assert np.array_equal(result[key], expected_probs[key, :])
+        assert np.allclose(result[key], expected_probs[key, :])
 
     result = real_app.predict_proba(classification_no_transforms["x"], as_dict=False)
-    assert np.array_equal(result, expected_probs)
+    assert np.allclose(result, expected_probs)
 
 
 def test_predict_series(regression_one_hot):

--- a/tests/realapp/test_realapp.py
+++ b/tests/realapp/test_realapp.py
@@ -89,6 +89,27 @@ def test_predict(regression_one_hot):
     assert np.array_equal(result, expected)
 
 
+def test_predict_proba(classification_no_transforms):
+    real_app = RealApp(
+        classification_no_transforms["model"],
+        classification_no_transforms["x"],
+        transformers=classification_no_transforms["transformers"],
+        classes=classification_no_transforms["classes"],
+    )
+
+    quantity = (
+        classification_no_transforms["coefs"].T @ classification_no_transforms["x"].to_numpy()
+    )
+    expected_probs = np.exp(quantity) / np.sum(np.exp(quantity), axis=1, keepdims=True)
+
+    result = real_app.predict_proba(classification_no_transforms["x"])
+    for key in result.keys():
+        assert np.array_equal(result[key], expected_probs[key, :])
+
+    result = real_app.predict_proba(classification_no_transforms["x"], as_dict=False)
+    assert np.array_equal(result, expected_probs)
+
+
 def test_predict_series(regression_one_hot):
     real_app = RealApp(
         regression_one_hot["model"],


### PR DESCRIPTION
This new feature will allow users to call realapp.predict_proba(), which is implemented through a wrapper function with the same name in the explainer object that calls the base model's predict_proba() after handling transformers.

This function only works for classification models.

Unit test of the new feature for the realapp project was added as well.
