### PR TITLE
Add a "no format" option to realapps

### DIFF
--- a/pyreal/benchmark/profiler.py
+++ b/pyreal/benchmark/profiler.py
@@ -1,17 +1,18 @@
 import cProfile
 import pstats
+
 from pyreal.sample_applications import ames_housing
 
 # Setup
 app = ames_housing.load_app()
 x = ames_housing.load_data()
-x = x.sample(10000, replace=True)
+x = x.sample(100000, replace=True)
 
 profiler = cProfile.Profile()
 profiler.enable()
 
 # Analysis code
-app.produce_feature_importance(format_output=False)
+app.produce_feature_contributions(x, format_output=False)
 profiler.disable()
 
 stats = pstats.Stats(profiler)

--- a/pyreal/benchmark/profiler.py
+++ b/pyreal/benchmark/profiler.py
@@ -5,12 +5,13 @@ from pyreal.sample_applications import ames_housing
 # Setup
 app = ames_housing.load_app()
 x = ames_housing.load_data()
+x = x.sample(10000, replace=True)
 
 profiler = cProfile.Profile()
 profiler.enable()
 
 # Analysis code
-app.produce_feature_contributions(x)
+app.produce_feature_importance(format_output=False)
 profiler.disable()
 
 stats = pstats.Stats(profiler)

--- a/pyreal/benchmark/profiler.py
+++ b/pyreal/benchmark/profiler.py
@@ -1,0 +1,18 @@
+import cProfile
+import pstats
+from pyreal.sample_applications import ames_housing
+
+# Setup
+app = ames_housing.load_app()
+x = ames_housing.load_data()
+
+profiler = cProfile.Profile()
+profiler.enable()
+
+# Analysis code
+app.produce_feature_contributions(x)
+profiler.disable()
+
+stats = pstats.Stats(profiler)
+# this is the only way I can figure out to filter only package function calls
+stats.sort_stats("tottime").print_stats("github")

--- a/tests/realapp/test_realapp_gfi.py
+++ b/tests/realapp/test_realapp_gfi.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from pandas.testing import assert_index_equal
 
 from pyreal import RealApp
 
@@ -61,6 +62,20 @@ def test_produce_global_feature_importance(regression_no_transforms):
 
     # confirm no bug in explainer caching
     realApp.produce_feature_importance(algorithm="permutation")
+
+
+def test_produce_global_feature_importance_no_format(regression_no_transforms):
+    realApp = RealApp(
+        regression_no_transforms["model"],
+        regression_no_transforms["x"],
+        y_train=regression_no_transforms["y"],
+        transformers=regression_no_transforms["transformers"],
+    )
+
+    explanation = realApp.produce_feature_importance(format_output=False)
+    assert explanation.shape == (1, regression_no_transforms["x"].shape[1])
+    assert_index_equal(explanation.columns, regression_no_transforms["x"].columns)
+    assert list(explanation.iloc[0]) == [4 / 3, 0, 0]
 
 
 def test_produce_global_feature_importance_no_data_on_init(regression_no_transforms):

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyreal import RealApp
 from pyreal.realapp.realapp import _get_average_or_mode
+from pandas.testing import assert_series_equal
 
 
 def test_average_or_mode():
@@ -71,7 +72,6 @@ def test_produce_local_feature_contributions(regression_no_transforms):
     )
     features = ["A", "B", "C"]
 
-    # x_one_dim = pd.DataFrame([[2, 10, 10]], columns=features)
     x_one_dim = pd.Series([2, 10, 10], index=features)
 
     expected = np.mean(regression_no_transforms["y"])
@@ -94,6 +94,25 @@ def test_produce_local_feature_contributions(regression_no_transforms):
     assert list(explanation[1]["Feature Value"]) == list(x_multi_dim.iloc[1])
     assert list(explanation[1]["Contribution"]) == [x_multi_dim.iloc[1, 0] - expected, 0, 0]
     assert list(explanation[1]["Average/Mode"]) == [3, 1.5, 2]
+
+
+def test_produce_local_feature_contributions_no_format(regression_no_transforms):
+    real_app = RealApp(
+        regression_no_transforms["model"],
+        regression_no_transforms["x"],
+        transformers=regression_no_transforms["transformers"],
+    )
+    features = ["A", "B", "C"]
+
+    x_multi_dim = pd.DataFrame([[2, 1, 1], [4, 2, 3]], columns=features)
+
+    expected = np.mean(regression_no_transforms["y"])
+    explanation = real_app.produce_feature_contributions(x_multi_dim, format_output=False)
+    assert explanation.shape == x_multi_dim.shape
+
+    assert_series_equal(explanation["A"], x_multi_dim["A"] - expected)
+    assert (explanation["B"] == 0).all()
+    assert (explanation["C"] == 0).all()
 
 
 def test_produce_local_feature_contributions_with_id_column(regression_one_hot):

--- a/tests/realapp/test_realapp_lfc.py
+++ b/tests/realapp/test_realapp_lfc.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.testing import assert_series_equal
 
 from pyreal import RealApp
 from pyreal.realapp.realapp import _get_average_or_mode
-from pandas.testing import assert_series_equal
 
 
 def test_average_or_mode():


### PR DESCRIPTION
Profiling has revealed that formatting outputs can be a major source of slow-down for RealApp objects, especially for LFC and SE. Formatting is only needed if users are looking at individual rows, and therefore not needed for large datasets. This PR makes it possible to skip formatting for a produce call, instead returning the simplest output format without any row_ids. This can be used when identifying individual rows is not necessary, and users just need large numbers of explanations.

For this PR, I've added this functionality for LFC and GFI. For SE, the original explainer format is already fairly slow and complex, so this fix will require adjustments to other parts of the code.

As part of this code, I'm also including the basic profiling code used to identify the issue. Future PRs will extend this profiling functionality.
