### PR TITLE
Fixing migration from sklearn

### DIFF
--- a/pyreal/transformers/one_hot_encode.py
+++ b/pyreal/transformers/one_hot_encode.py
@@ -177,7 +177,7 @@ class OneHotEncoder(TransformerBase):
             raise RuntimeError("Must fit one hot encoder before transforming")
         x_to_encode = x[self.columns]
         x_cat_ohe = self.ohe.transform(x_to_encode)
-        return pd.concat([x.drop(self.columns, axis="columns"), x_cat_ohe], axis=1)
+        return pd.concat([x_cat_ohe, x.drop(self.columns, axis="columns")], axis=1)
 
     def inverse_data_transform(self, x_new):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ def regression_one_hot(test_root):
     y = pd.DataFrame([1, 2, 3])
     model_one_hot = LinearRegression()
     model_one_hot.fit(x_trans, y)
-    model_one_hot.coef_ = np.array([0, 0, 1, 2, 3])
+    model_one_hot.coef_ = np.array([1, 2, 3, 0, 0])
     model_one_hot.intercept_ = 0
     model_one_hot_filename = os.path.join(test_root, "data", "model_one_hot.pkl")
     with open(model_one_hot_filename, "wb") as f:

--- a/tests/explainers/test_base_explainer.py
+++ b/tests/explainers/test_base_explainer.py
@@ -54,7 +54,10 @@ def test_transform_to_functions(regression_one_hot):
 
 def test_transform_to_functions_series(regression_one_hot):
     x = pd.Series([2, 1, 3], index=["A", "B", "C"])
-    expected = pd.Series([1, 3, 1, 0, 0], index=["B", "C", "A_2", "A_4", "A_6"])
+    expected = pd.Series(
+        [1, 0, 0, 1, 3],
+        index=["A_2", "A_4", "A_6", "B", "C"],
+    )
 
     regression_one_hot["transformers"].set_flags(model=True, interpret=True)
     feature_select = FeatureSelectTransformer(columns=["B", "A_2"], algorithm=False, model=True)

--- a/tests/realapp/test_realapp_migration_functions.py
+++ b/tests/realapp/test_realapp_migration_functions.py
@@ -17,7 +17,7 @@ from pyreal.transformers import (
 
 class DummyTransformer:
     def transform(self, X):
-        return X
+        return X * 2
 
     def fit(self, *args, **kwargs):
         return self

--- a/tests/realapp/test_realapp_migration_functions.py
+++ b/tests/realapp/test_realapp_migration_functions.py
@@ -10,8 +10,8 @@ from pyreal.transformers import (
     ColumnDropTransformer,
     OneHotEncoder,
     Transformer,
-    run_transformers,
     fit_transformers,
+    run_transformers,
 )
 
 
@@ -89,12 +89,12 @@ def test_realapp_from_sklearn_pipeline(fitted):
 def test_realapp_from_sklearn_pipeline_with_column_transformer(fitted):
     model = LinearRegression()
     column_transformer = ColumnTransformer(
-        [("onehot", SklearnOneHotEncoder(), ["a"]), ("drop", "drop", ["b"])],
+        [("onehot", SklearnOneHotEncoder(), ["c"]), ("drop", "drop", ["b"])],
         remainder="passthrough",
     )
     pipeline = Pipeline([("column_transformer", column_transformer), ("model", model)])
 
-    X = pd.DataFrame([[1, 2, 3], [3, 4, 5]], columns=["a", "b", "c"])
+    X = pd.DataFrame([[1, 2, 3, 4], [3, 4, 5, 6]], columns=["a", "b", "c", "d"])
     y = pd.Series([1, 2])
     if fitted:
         pipeline.fit(X, y)
@@ -104,7 +104,7 @@ def test_realapp_from_sklearn_pipeline_with_column_transformer(fitted):
     assert realapp.y_train is y
     assert len(realapp.transformers) == 2
     assert isinstance(realapp.transformers[0], OneHotEncoder)
-    assert realapp.transformers[0].columns == ["a"]
+    assert realapp.transformers[0].columns == ["c"]
     assert isinstance(realapp.transformers[1], ColumnDropTransformer)
     assert realapp.transformers[1].dropped_columns == ["b"]
 

--- a/tests/realapp/test_realapp_migration_functions.py
+++ b/tests/realapp/test_realapp_migration_functions.py
@@ -6,12 +6,21 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder as SklearnOneHotEncoder
 
 from pyreal import RealApp
-from pyreal.transformers import ColumnDropTransformer, OneHotEncoder, Transformer
+from pyreal.transformers import (
+    ColumnDropTransformer,
+    OneHotEncoder,
+    Transformer,
+    run_transformers,
+    fit_transformers,
+)
 
 
 class DummyTransformer:
     def transform(self, X):
         return X
+
+    def fit(self, *args, **kwargs):
+        return self
 
 
 def test_realapp_from_sklearn_model_only():
@@ -24,12 +33,16 @@ def test_realapp_from_sklearn_model_only():
     assert realapp.y_train is y
 
 
-def test_realapp_from_sklearn_model_and_transformers():
+@pytest.mark.parametrize("fitted", [True, False])
+def test_realapp_from_sklearn_model_and_transformers(fitted):
     model = LinearRegression()
     transformers = [SklearnOneHotEncoder(), DummyTransformer()]
 
     X = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
     y = pd.Series([1, 2])
+
+    if fitted:
+        fit_transformers(transformers, X)
     realapp = RealApp.from_sklearn(model=model, transformers=transformers, X_train=X, y_train=y)
     assert realapp.models[0] is model
     assert realapp.X_train_orig is X
@@ -40,14 +53,22 @@ def test_realapp_from_sklearn_model_and_transformers():
     assert isinstance(realapp.transformers[1], Transformer)
     assert realapp.transformers[1].wrapped_transformer is transformers[1]
 
+    if fitted:
+        sklearn_data = run_transformers(transformers, X)
+        pyreal_data = run_transformers(realapp.transformers, X).to_numpy()
+        assert (sklearn_data == pyreal_data).all()
 
-def test_realapp_from_sklearn_pipeline():
+
+@pytest.mark.parametrize("fitted", [True, False])
+def test_realapp_from_sklearn_pipeline(fitted):
     model = LinearRegression()
     dummy = DummyTransformer()
     pipeline = Pipeline([("onehot", SklearnOneHotEncoder()), ("dummy", dummy), ("model", model)])
 
     X = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
     y = pd.Series([1, 2])
+    if fitted:
+        pipeline.fit(X, y)
     realapp = RealApp.from_sklearn(pipeline=pipeline, X_train=X, y_train=y)
     assert realapp.models[0] is model
     assert realapp.X_train_orig is X
@@ -58,16 +79,22 @@ def test_realapp_from_sklearn_pipeline():
     assert isinstance(realapp.transformers[1], Transformer)
     assert realapp.transformers[1].wrapped_transformer is dummy
 
+    if fitted:
+        sklearn_data = pipeline["dummy"].transform(pipeline["onehot"].transform(X))
+        pyreal_data = run_transformers(realapp.transformers, X).to_numpy()
+        assert (sklearn_data == pyreal_data).all()
+
 
 @pytest.mark.parametrize("fitted", [True, False])
 def test_realapp_from_sklearn_pipeline_with_column_transformer(fitted):
     model = LinearRegression()
     column_transformer = ColumnTransformer(
-        [("onehot", SklearnOneHotEncoder(), ["a"]), ("drop", "drop", ["b"])]
+        [("onehot", SklearnOneHotEncoder(), ["a"]), ("drop", "drop", ["b"])],
+        remainder="passthrough",
     )
     pipeline = Pipeline([("column_transformer", column_transformer), ("model", model)])
 
-    X = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    X = pd.DataFrame([[1, 2, 3], [3, 4, 5]], columns=["a", "b", "c"])
     y = pd.Series([1, 2])
     if fitted:
         pipeline.fit(X, y)
@@ -80,3 +107,8 @@ def test_realapp_from_sklearn_pipeline_with_column_transformer(fitted):
     assert realapp.transformers[0].columns == ["a"]
     assert isinstance(realapp.transformers[1], ColumnDropTransformer)
     assert realapp.transformers[1].dropped_columns == ["b"]
+
+    if fitted:
+        sklearn_data = pipeline["column_transformer"].transform(X)
+        pyreal_data = run_transformers(realapp.transformers, X).to_numpy()
+        assert (sklearn_data == pyreal_data).all()

--- a/tests/transformers/test_one_hot_encode.py
+++ b/tests/transformers/test_one_hot_encode.py
@@ -18,7 +18,11 @@ def test_fit_transform_one_hot_encoder(transformer_test_data):
         [[1, 9, 0, 1, 0, 1, 0, 0], [3, 0, 0, 0, 1, 0, 1, 0], [7, 2, 1, 0, 0, 0, 0, 1]],
         columns=["B", "D", "C_2", "C_3", "C_4", "A_2", "A_4", "A_6"],
     )
-    assert_frame_equal(transformed_x, expected_transformed_x, check_dtype=False)
+    assert_frame_equal(
+        transformed_x.sort_index(axis=1),
+        expected_transformed_x.sort_index(axis=1),
+        check_dtype=False,
+    )
 
 
 def test_transform_one_hot_encoder(transformer_test_data):
@@ -30,7 +34,11 @@ def test_transform_one_hot_encoder(transformer_test_data):
         [[0, 1, 1, 0, 0, 0, 0, 1], [1, 8, 0, 1, 0, 0, 1, 0], [0, 3, 0, 0, 1, 1, 0, 0]],
         columns=["B", "D", "C_2", "C_3", "C_4", "A_2", "A_4", "A_6"],
     )
-    assert_frame_equal(transformed_x, expected_transformed_x, check_dtype=False)
+    assert_frame_equal(
+        transformed_x.sort_index(axis=1),
+        expected_transformed_x.sort_index(axis=1),
+        check_dtype=False,
+    )
 
 
 def test_transform_all_columns_one_hot_encoder(transformer_test_data):


### PR DESCRIPTION
Fixing an issue where migrating from sklearn led to a different feature column order by updating OneHotEncoder to use the same column order logic as sklearn.