### PR TITLE
Adding row ids to similar examples output

### DIFF
--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -1238,9 +1238,14 @@ class RealApp:
                 if return_ids:
                     ids = x_train_orig[self.id_column]
                     return x_train_orig.drop(columns=self.id_column), ids
-            return x_train_orig, None
+                return x_train_orig.drop(columns=self.id_column)
+            if return_ids:
+                return x_train_orig, None
+            return x_train_orig
         else:
-            return self.X_train_orig, self.training_ids_for_se
+            if return_ids:
+                return self.X_train_orig, self.training_ids_for_se
+            return self.X_train_orig
 
     def _get_y_train(self, y_train):
         """

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -239,13 +239,13 @@ class RealApp:
 
         self.id_column = id_column
 
-        self.training_ids = None
+        self.training_ids_for_se = None
         if (
             X_train_orig is not None
             and self.id_column is not None
             and self.id_column in X_train_orig
         ):
-            self.training_ids = X_train_orig[self.id_column]
+            self.training_ids_for_se = X_train_orig[self.id_column]
             self.X_train_orig = X_train_orig.drop(columns=self.id_column)
         else:
             self.X_train_orig = X_train_orig
@@ -1007,7 +1007,7 @@ class RealApp:
         )
         x_train, training_ids = self._get_x_train_orig(x_train_orig, return_ids=True)
         explainer.fit(x_train, self._get_y_train(y_train))
-        self.training_ids = training_ids
+        self.training_ids_for_se = training_ids
         self._add_explainer("se", algorithm, explainer)
         return explainer
 
@@ -1068,7 +1068,7 @@ class RealApp:
         format_kwargs = dict()
         if format_y:
             format_kwargs["y_format_func"] = self.pred_format_func
-            format_kwargs["training_ids"] = self.training_ids
+            format_kwargs["training_ids"] = self.training_ids_for_se
             format_kwargs["id_column_name"] = self.id_column
 
         return self._produce_explanation_helper(
@@ -1240,7 +1240,7 @@ class RealApp:
                     return x_train_orig.drop(columns=self.id_column), ids
             return x_train_orig, None
         else:
-            return self.X_train_orig, self.training_ids
+            return self.X_train_orig, self.training_ids_for_se
 
     def _get_y_train(self, y_train):
         """

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -28,6 +28,37 @@ def test_produce_similar_examples(regression_one_hot_with_interpret):
     assert_series_equal(explanation["id2"]["y"], y.iloc[[3, 0]])
 
 
+def test_produce_similar_examples_id_column(regression_one_hot):
+    x = pd.DataFrame(
+        [[2, 0, 0, "id1"], [6, 6, 6, "id2"], [6, 7, 8, "id3"], [2, 0, 1, "id4"]],
+        columns=["A", "B", "C", "ID"],
+    )
+    y = pd.Series([1, 0, 0, 1])
+    real_app = RealApp(
+        regression_one_hot["model"],
+        X_train_orig=x,
+        y_train=y,
+        transformers=regression_one_hot["transformers"],
+        id_column="ID",
+    )
+
+    input_rows = pd.DataFrame([["id1", 6, 7, 9], ["id2", 2, 1, 1]], columns=["ID", "A", "B", "C"])
+    explanation = real_app.produce_similar_examples(input_rows, num_examples=2)
+    assert "id1" in explanation
+    for key in explanation:
+        print(key)
+        for key2 in explanation[key]:
+            print(key2)
+            print(explanation[key][key2])
+    assert_frame_equal(explanation["id1"]["X"], x.iloc[[2, 1], :])
+    assert_series_equal(explanation["id1"]["y"], y.iloc[[2, 1]])
+    assert_series_equal(explanation["id1"]["Input"], input_rows.iloc[0, 1:], check_dtype=False)
+
+    assert "id2" in explanation
+    assert_frame_equal(explanation["id2"]["X"], x.iloc[[3, 0], :])
+    assert_series_equal(explanation["id2"]["y"], y.iloc[[3, 0]])
+
+
 def test_prepare_similar_examples(regression_no_transforms):
     real_app = RealApp(
         regression_no_transforms["model"],

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -93,7 +93,13 @@ def test_prepare_similar_examples_with_id_column(regression_no_transforms):
     real_app.prepare_similar_examples(x_train_orig=x_multi_dim, y_train=pd.Series([0, 1, 1]))
 
     # Confirm explainer was prepped and now works without being given data
-    real_app.produce_similar_examples(x_multi_dim, num_examples=1)
+    examples = real_app.produce_similar_examples(x_multi_dim, num_examples=1)
+    assert_frame_equal(examples["a"]["X"], x_multi_dim.iloc[0:1, :])
+    assert examples["a"]["y"].iloc[0] == 0
+    assert_frame_equal(examples["b"]["X"], x_multi_dim.iloc[1:2, :])
+    assert examples["b"]["y"].iloc[0] == 1
+    assert_frame_equal(examples["c"]["X"], x_multi_dim.iloc[2:3, :])
+    assert examples["c"]["y"].iloc[0] == 1
 
 
 def test_produce_similar_examples_with_standardization(dummy_model):


### PR DESCRIPTION
If row ids are including in the training dataset, they will now also be included in the similar examples return.