### PR TITLE
Adding NarrativeTransformer

### DIFF
--- a/docs/api_reference/transformer.rst
+++ b/docs/api_reference/transformer.rst
@@ -89,3 +89,10 @@ Geo Transformers
 
     LatLongToPlace
 
+Narrative Transformers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+    :toctree: api/
+
+    NarrativeTransformer
+

--- a/pyreal/explainers/base.py
+++ b/pyreal/explainers/base.py
@@ -387,6 +387,10 @@ class ExplainerBase(ABC):
 
         # Iterate through algorithm transformers
         for i, t in enumerate(a_transformers[::-1]):
+            if t.require_values:
+                explanation.update_values(  # UNTESTED
+                    run_transformers(a_transformers[0 : len(a_transformers) - i], x), inplace=True
+                )
             try:
                 explanation = t.inverse_transform_explanation(explanation)
             # If this is a breaking transformer, transform x to the current point and return
@@ -404,6 +408,8 @@ class ExplainerBase(ABC):
                     return explanation
         # Iterate through interpret transformers
         for t in i_transformers:
+            if t.require_values and x is not None:
+                explanation.update_values(x, inplace=True)
             if not t.algorithm:
                 try:
                     explanation = t.transform_explanation(explanation)

--- a/pyreal/explanation_types/__init__.py
+++ b/pyreal/explanation_types/__init__.py
@@ -18,6 +18,7 @@ from pyreal.explanation_types.feature_value_based import (
     PartialDependenceExplanation,
 )
 from pyreal.explanation_types.time_series_saliency import TimeSeriesSaliency
+from pyreal.explanation_types.narrative import NarrativeExplanation
 
 __all__ = [
     "Explanation",
@@ -34,4 +35,5 @@ __all__ = [
     "FeatureValueBased",
     "PartialDependenceExplanation",
     "TimeSeriesSaliency",
+    "NarrativeExplanation",
 ]

--- a/pyreal/explanation_types/narrative.py
+++ b/pyreal/explanation_types/narrative.py
@@ -1,0 +1,9 @@
+from pyreal.explanation_types import Explanation
+
+
+class NarrativeExplanation(Explanation):
+    def validate(self):
+        if not isinstance(self.explanation, list):
+            raise AssertionError("Explanation must be a list of strings")
+        for instance in self.explanation:
+            assert isinstance(instance, str), "Explanation must be a list of strings"

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -778,6 +778,8 @@ class RealApp:
         """
         Produce a feature contribution explanation, formatted in natural language sentence
         format using LLMs.
+        Do not use this function if your transformer list ends with a NarrativeTransformer -
+        simply call produce_feature_contributions instead.
 
         Args:
             x_orig (DataFrame of shape (n_instances, n_features) or Series of length (n_features)):

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -260,7 +260,7 @@ class RealApp:
         self.class_descriptions = class_descriptions
         self.pred_format_func = pred_format_func
 
-        if isinstance(transformers, list):
+        if transformers is None or isinstance(transformers, list):
             self.transformers = transformers
         else:  # assume single transformer given
             self.transformers = [transformers]

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -465,7 +465,7 @@ class RealApp:
                 if ids is None:
                     ids = x_orig.index
                 return format_narratives(
-                    narratives,
+                    narratives.get(),
                     ids=ids,
                     series=series,
                     optimized=not format_output,
@@ -491,7 +491,7 @@ class RealApp:
                     )
         else:
             if narrative:
-                return explainer.produce_narrative_explanation(**produce_kwargs)
+                return explainer.produce_narrative_explanation(**produce_kwargs).get()
             else:
                 explanation = explainer.produce(**produce_kwargs)
                 return format_output_func(

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -264,7 +264,6 @@ class RealApp:
             self.transformers = transformers
         else:  # assume single transformer given
             self.transformers = [transformers]
-        self.transformers = transformers
         self.feature_descriptions = feature_descriptions
 
         if openai_client is not None:

--- a/pyreal/realapp/realapp.py
+++ b/pyreal/realapp/realapp.py
@@ -10,6 +10,7 @@ from pyreal.explainers import (
 )
 from pyreal.transformers import run_transformers, sklearn_pipeline_to_pyreal_transformers
 from pyreal.utils import get_top_contributors
+from pyreal.explanation_types import NarrativeExplanation
 
 
 def format_feature_contribution_output(explanation, ids=None, series=False, optimized=False):
@@ -472,9 +473,22 @@ class RealApp:
                 )
             else:
                 explanation = explainer.produce(x_orig, **produce_kwargs)
-                return format_output_func(
-                    explanation, ids, optimized=not format_output, series=series, **format_kwargs
-                )
+                if isinstance(explanation, NarrativeExplanation):
+                    return format_narratives(
+                        explanation.get(),
+                        ids=ids,
+                        series=series,
+                        optimized=not format_output,
+                        **format_kwargs
+                    )
+                else:
+                    return format_output_func(
+                        explanation,
+                        ids,
+                        optimized=not format_output,
+                        series=series,
+                        **format_kwargs
+                    )
         else:
             if narrative:
                 return explainer.produce_narrative_explanation(**produce_kwargs)

--- a/pyreal/transformers/__init__.py
+++ b/pyreal/transformers/__init__.py
@@ -34,6 +34,7 @@ from pyreal.transformers.scale import MinMaxScaler, StandardScaler, Normalizer
 from pyreal.transformers.geo import LatLongToPlace
 from pyreal.transformers.generic_transformer import Transformer
 from pyreal.transformers.utils import sklearn_pipeline_to_pyreal_transformers
+from pyreal.transformers.llm import NarrativeTransformer
 
 __all__ = [
     "TransformerBase",
@@ -67,6 +68,7 @@ __all__ = [
     "Normalizer",
     "StandardScaler",
     "LatLongToPlace",
+    "NarrativeTransformer",
     "sklearn_pipeline_to_pyreal_transformers",
     "Transformer",
 ]

--- a/pyreal/transformers/base.py
+++ b/pyreal/transformers/base.py
@@ -109,7 +109,7 @@ class TransformerBase(ABC):
     to a second, and explanations from the second back to the first.
     """
 
-    def __init__(self, model=True, interpret=False, algorithm=None):
+    def __init__(self, model=True, interpret=False, algorithm=None, require_values=False):
         """
         Set this Transformer's flags.
 
@@ -124,6 +124,9 @@ class TransformerBase(ABC):
                 algorithm is False, but model is True, this transformer will be applied only
                 when making model predictions during the explanation algorithm. Cannot be True if
                 if the model flag is False
+            require_values (Boolean):
+                If True, this transformer must be given values alongside the explanation in order
+                to work for local explanations (for global explanations, this parameter is ignored)
         """
         self.model = model
         self.interpret = interpret
@@ -134,6 +137,8 @@ class TransformerBase(ABC):
         if self.model is False and self.algorithm is True:
             raise ValueError("algorithm flag cannot be True if model flag is False")
         self.fitted = False
+
+        self.require_values = require_values
 
     def set_flags(self, model=None, interpret=None, algorithm=None):
         if model is not None:

--- a/pyreal/transformers/llm.py
+++ b/pyreal/transformers/llm.py
@@ -14,6 +14,7 @@ class NarrativeTransformer(TransformerBase):
         context_description="",
         max_tokens=200,
         temperature=0.5,
+        **kwargs,
     ):
         """
         Transforms explanations to narrative (natural-language) form.
@@ -63,7 +64,12 @@ class NarrativeTransformer(TransformerBase):
 
         self.few_shot_training_examples = {}
 
-        super().__init__()
+        if "interpret" not in kwargs:
+            kwargs["interpret"] = True
+        if "model" not in kwargs:
+            kwargs["model"] = False
+
+        super().__init__(require_values=True, **kwargs)
 
     def data_transform(self, x):
         return x
@@ -106,7 +112,7 @@ class NarrativeTransformer(TransformerBase):
             raise ValueError(
                 "Invalid detail_level %s. Expected one of ['high', 'low']" % self.detail_level
             )
-        # explanation = explanation.get_top_features(num_features=num_features)
+
         narrative_explanations = []
         base_messages = [{"role": "system", "content": prompt}]
         if "feature_contributions" in self.few_shot_training_examples:

--- a/pyreal/transformers/llm.py
+++ b/pyreal/transformers/llm.py
@@ -1,6 +1,7 @@
-from pyreal.transformers import TransformerBase
 from openai import OpenAI
+
 from pyreal.explanation_types import NarrativeExplanation
+from pyreal.transformers import TransformerBase
 
 
 class NarrativeTransformer(TransformerBase):
@@ -85,6 +86,32 @@ class NarrativeTransformer(TransformerBase):
 
     def fit(self, x, **params):
         return self
+
+    def set_training_examples(self, explanation_type, training_examples, replace=False):
+        """
+        Set examples of narrative explanations for the request explanation type.
+
+        Args:
+            explanation_type (string):
+                Type of explanation to set examples for. Currently only "feature_contributions"
+                is supported.
+            training_examples (list of tuples):
+                List of tuples, where the first element is the input to the model
+                and the second element is the example output.
+            replace (bool):
+                If True, replace existing examples. If False, append to existing examples.
+        """
+        if explanation_type not in ["feature_contributions"]:
+            raise ValueError(
+                "Invalid training example type %s. Expected one of ['feature_contributions']"
+                % explanation_type
+            )
+        if replace:
+            self.training_examples[explanation_type] = training_examples
+        else:
+            if self.training_examples.get(explanation_type) is None:
+                self.training_examples[explanation_type] = []
+            self.training_examples[explanation_type].extend(training_examples)
 
     def transform_explanation_feature_contribution(self, explanation, num_features=None):
         if num_features is None:

--- a/pyreal/transformers/llm.py
+++ b/pyreal/transformers/llm.py
@@ -5,6 +5,10 @@ from pyreal.transformers import TransformerBase
 
 
 class NarrativeTransformer(TransformerBase):
+    """
+    Transforms explanations to narrative (natural-language) form.
+    """
+
     def __init__(
         self,
         openai_client=None,

--- a/pyreal/transformers/llm.py
+++ b/pyreal/transformers/llm.py
@@ -1,0 +1,221 @@
+from pyreal.transformers import TransformerBase
+from openai import OpenAI
+from pyreal.explanation_types import NarrativeExplanation
+
+
+class NarrativeTransformer(TransformerBase):
+    def __init__(
+        self,
+        openai_client=None,
+        openai_api_key=None,
+        num_features=5,
+        llm_model="gpt3.5",
+        detail_level="high",
+        context_description="",
+        max_tokens=200,
+        temperature=0.5,
+    ):
+        """
+        Transforms explanations to narrative (natural-language) form.
+        Args:
+            x_orig (DataFrame of shape (n_instances, n_features):
+                Input to explain
+            num_features (int):
+                Number of features to include in the explanation, when relevant.
+                If None, all features will be included
+            llm_model (string):
+                One of ["gpt3.5", "gpt4"]. LLM model to use to generate the explanation.
+                GPT4 may provide better results, but is more expensive.
+            detail_level (string):
+                One of ["high", "low"]. Level of detail to include in the explanation.
+                High detail should include precise contribution values. Low detail
+                will include only basic information about features used.
+            context_description (string):
+                Description of the model's prediction task, in sentence format. This will be
+                passed to the LLM and may help produce more accurate explanations.
+                For example: "The model predicts the price of houses."
+            max_tokens (int):
+                Maximum number of tokens to use in the explanation
+            temperature (float):
+                LLM Temperature to use. Values closer to 1 will produce more creative values.
+                Values closer to 0 will produce more consistent or conservative explanations.
+            openai_client (OpenAI API client):
+                OpenAI API client, with API key set. If None, the API key must be provided to the
+                explainer at initialization.
+
+        Returns:
+            list of strings of length n_instances
+                Narrative version of feature contribution explanation, one item per instance
+        """
+        if openai_client is not None:
+            self.openai_client = openai_client
+        elif openai_api_key is not None:
+            self.openai_client = OpenAI(api_key=openai_api_key)
+        else:
+            raise ValueError("Must provide openai_client or openai_api_key")
+
+        self.num_features = num_features
+        self.llm_model = llm_model
+        self.detail_level = detail_level
+        self.context_description = context_description
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+        self.few_shot_training_examples = {}
+
+        super().__init__()
+
+    def data_transform(self, x):
+        return x
+
+    def fit(self, x, **params):
+        return self
+
+    def transform_explanation_feature_contribution(self, explanation, num_features=None):
+        if num_features is None:
+            num_features = self.num_features
+        if self.llm_model == "gpt3.5":
+            model = "gpt-3.5-turbo-0125"
+        elif self.llm_model == "gpt4":
+            model = "gpt-4-0125-preview"
+        else:
+            raise ValueError(
+                "Invalid LLM model %s. Expected one of ['gpt3.5', 'gpt4']" % self.llm_model
+            )
+        if self.context_description is None:
+            context_description = ""
+        else:
+            context_description = self.context_description.strip()
+            if not context_description.endswith("."):
+                context_description += "."
+        prompt = (
+            "You are helping users who do not have experience working with ML understand an ML"
+            f" model's predictions. {context_description} I will give you feature contribution"
+            " explanations, generated using SHAP, in (feature, feature_value, contribution )"
+            " format. Convert the explanations into simple narratives. Do not use more tokens"
+            " than necessary. Make your answers sound very natural, as if said in conversation. "
+        )
+        if self.detail_level == "low":
+            prompt += (
+                "Keep the explanations simple and easy to understand. Do not include exact"
+                " contribution values. "
+            )
+        elif self.detail_level == "high":
+            prompt += "Include all exact contribution values in your response. "
+        else:
+            raise ValueError(
+                "Invalid detail_level %s. Expected one of ['high', 'low']" % self.detail_level
+            )
+        # explanation = explanation.get_top_features(num_features=num_features)
+        narrative_explanations = []
+        base_messages = [{"role": "system", "content": prompt}]
+        if "feature_contributions" in self.few_shot_training_examples:
+            for training_exp, training_narr in self.few_shot_training_examples[
+                "feature_contributions"
+            ]:
+                base_messages.append({"role": "user", "content": training_exp})
+                base_messages.append({"role": "assistant", "content": training_narr})
+        parsed_explanations = parse_feature_contribution_explanation_for_llm(
+            explanation, num_features=num_features
+        )
+        for parsed_explanation in parsed_explanations:
+            messages = base_messages + [{"role": "user", "content": parsed_explanation}]
+            response = self.openai_client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+            )
+            narrative_explanations.append(response.choices[0].message.content)
+        return NarrativeExplanation(narrative_explanations)
+
+
+def parse_feature_contribution_explanation_for_llm(explanation, num_features=None):
+    explanations = explanation.get_top_features(num_features=num_features)
+    parsed_explanations = []
+    for explanation in explanations:
+        strings = []
+        for feature, value, contribution in zip(
+            explanation[0].index, explanation[1], explanation[0]
+        ):
+            strings.append(f"({feature}, {value}, {contribution})")
+        parsed_explanations.append(", ".join(strings))
+    return parsed_explanations
+
+
+def train_feature_contributions(
+    self, x_train=None, live=True, provide_examples=False, num_inputs=5, num_features=3
+):
+    """
+    Run the training process for the LLM model used to generate narrative feature
+    contribution explanations.
+
+    Args:
+        x_train (DataFrame of shape (n_instances, n_features)):
+            Training set to take sample inputs from. If None, the training set must be provided
+            to the explainer at initialization.
+        live (Boolean):
+            If True, run the training process through CLI input/outputs. If False,
+            this function will generate a shell training file that will need to be filled out
+            and added to the RealApp manually. Currently only live training is supported.
+        provide_examples (Boolean):
+            If True, generate a base example of explanations at each step. This may make
+            the process faster, but will incur costs to your OpenAI API account.
+        num_inputs (int):
+            Number of inputs to request.
+        num_features (int):
+            Number of features to include per explanation. If None, all features will be
+            included
+
+    Returns:
+        list of (explanation, narrative) pairs
+            The generated training data
+    """
+    if not live:
+        raise NotImplementedError("Non-interactive training not yet implemented")
+    if provide_examples and self.openai_client is None:
+        raise ValueError(
+            "OpenAI API key or client must be provided to provide examples during training"
+        )
+    x_train = self._get_x_train_orig(x_train)
+    if num_inputs > len(x_train):
+        print(
+            "Warning: number of inputs in x_train is less than num_inputs, using all available"
+            " inputs"
+        )
+    else:
+        x_train = x_train.sample(num_inputs)
+    explanation = self.produce(x_train)
+    parsed_explanations = parse_feature_contribution_explanation_for_llm(
+        explanation, num_features=num_features
+    )
+    narratives = []
+    print("For each of the following inputs, please provide an appropriate narrative version.")
+    for i in range(num_inputs):
+        instruction = ""
+        parsed_explanation_formatted = parsed_explanations[i].replace("), ", "),\n")
+        instruction += (
+            f"Input {i+1} (feature, value, contribution):\n{parsed_explanation_formatted}\n"
+        )
+        if provide_examples:
+            example = self.transform_feature_contributions(
+                explanation[i], num_features=num_features
+            ).get()[0]
+            instruction += f"Example: {example}\n"
+            instruction += "Narrative explanation ('k' to keep example, 'q' to quit): "
+            narrative = input(instruction)
+            if narrative.lower() == "k":
+                narrative = example
+        else:
+            instruction += "Narrative explanation ('q' to quit): "
+            narrative = input(instruction)
+        if narrative.lower() == "q":
+            break
+        narratives.append((parsed_explanations[i], narrative))
+    if len(narratives) > 0 and input("Save training data? (y/n): ").lower() == "y":
+        self.llm_training_data = narratives
+        print(f"Training complete. Training data: {narratives}")
+    else:
+        print("Training data not saved.")
+    self.few_shot_training_examples["feature_contributions"] = narratives
+    return narratives

--- a/tests/explainers/lfc/test_local_feature_contribution.py
+++ b/tests/explainers/lfc/test_local_feature_contribution.py
@@ -88,11 +88,11 @@ def test_produce_narrative_explanation(regression_one_hot, mock_openai_client):
     )
 
     x_one_dim = pd.DataFrame([[2, 10, 10]], columns=["A", "B", "C"])
-    explanation = lfc.produce_narrative_explanation(x_one_dim)
+    explanation = lfc.produce_narrative_explanation(x_one_dim).get()
     assert explanation[0] == mock_openai_client["response"]
 
     x_multi_dim = pd.DataFrame([[2, 10, 10], [2, 11, 11]], columns=["A", "B", "C"])
-    explanation = lfc.produce_narrative_explanation(x_multi_dim)
+    explanation = lfc.produce_narrative_explanation(x_multi_dim).get()
     assert explanation[0] == mock_openai_client["response"]
     assert explanation[1] == mock_openai_client["response"]
 
@@ -112,7 +112,7 @@ def test_produce_narrative_explanation_with_training(regression_one_hot, mock_op
     assert lfc.llm_training_data is training_data
 
     x_one_dim = pd.DataFrame([[2, 10, 10]], columns=["A", "B", "C"])
-    explanation = lfc.produce_narrative_explanation(x_one_dim)
+    explanation = lfc.produce_narrative_explanation(x_one_dim).get()
     assert explanation[0] == mock_openai_client["response"]
 
     lfc.clear_llm_training_data()

--- a/tests/realapp/test_realapp_se.py
+++ b/tests/realapp/test_realapp_se.py
@@ -45,11 +45,6 @@ def test_produce_similar_examples_id_column(regression_one_hot):
     input_rows = pd.DataFrame([["id1", 6, 7, 9], ["id2", 2, 1, 1]], columns=["ID", "A", "B", "C"])
     explanation = real_app.produce_similar_examples(input_rows, num_examples=2)
     assert "id1" in explanation
-    for key in explanation:
-        print(key)
-        for key2 in explanation[key]:
-            print(key2)
-            print(explanation[key][key2])
     assert_frame_equal(explanation["id1"]["X"], x.iloc[[2, 1], :])
     assert_series_equal(explanation["id1"]["y"], y.iloc[[2, 1]])
     assert_series_equal(explanation["id1"]["Input"], input_rows.iloc[0, 1:], check_dtype=False)

--- a/tests/transformers/test_narrative_transformer.py
+++ b/tests/transformers/test_narrative_transformer.py
@@ -1,0 +1,19 @@
+from pyreal.transformers import NarrativeTransformer
+from pyreal.explanation_types import FeatureContributionExplanation
+import pandas as pd
+import yaml
+
+
+def test_transform_feature_contribution():
+    with open("../keys.yml", "r") as file:
+        config = yaml.safe_load(file)
+        openai_api_key = config["openai_api_key"]
+
+    contributions = pd.DataFrame(
+        [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]], columns=["A", "B", "C"]
+    )
+    values = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["A", "B", "C"])
+    explanation = FeatureContributionExplanation(contributions, values)
+    transformer = NarrativeTransformer(openai_api_key=openai_api_key)
+    transformed_explanation = transformer.transform_explanation(explanation)
+    print(transformed_explanation.get())

--- a/tests/transformers/test_narrative_transformer.py
+++ b/tests/transformers/test_narrative_transformer.py
@@ -2,6 +2,7 @@ from pyreal.transformers import NarrativeTransformer
 from pyreal.explanation_types import FeatureContributionExplanation
 import pandas as pd
 import yaml
+from pyreal.explainers import LocalFeatureContribution
 
 
 def test_transform_feature_contribution():
@@ -17,3 +18,27 @@ def test_transform_feature_contribution():
     transformer = NarrativeTransformer(openai_api_key=openai_api_key)
     transformed_explanation = transformer.transform_explanation(explanation)
     print(transformed_explanation.get())
+
+
+def test_transform_feature_contribution_full_workflow(regression_one_hot):
+    with open("../keys.yml", "r") as file:
+        config = yaml.safe_load(file)
+        openai_api_key = config["openai_api_key"]
+
+    model = regression_one_hot
+    x = model["x"]
+    lfc = LocalFeatureContribution(
+        model=model["model"],
+        e_algorithm="shap",
+        transformers=[model["transformers"]]
+        + [NarrativeTransformer(openai_api_key=openai_api_key)],
+    )
+    lfc.fit(x)
+
+    x_one_dim = pd.DataFrame([[2, 10, 10]], columns=["A", "B", "C"])
+    x_multi_dim = pd.DataFrame([[4, 1, 1], [6, 2, 3]], columns=["A", "B", "C"])
+    contributions = lfc.produce(x_one_dim).get()
+    print(contributions)
+
+    contributions = lfc.produce(x_multi_dim).get()
+    print(contributions)

--- a/tests/transformers/test_narrative_transformer.py
+++ b/tests/transformers/test_narrative_transformer.py
@@ -1,9 +1,9 @@
-from pyreal.transformers import NarrativeTransformer
-from pyreal.explanation_types import FeatureContributionExplanation
 import pandas as pd
-import yaml
-from pyreal.explainers import LocalFeatureContribution
+
 from pyreal import RealApp
+from pyreal.explainers import LocalFeatureContribution
+from pyreal.explanation_types import FeatureContributionExplanation
+from pyreal.transformers import NarrativeTransformer
 
 
 def test_transform_feature_contribution(mock_openai_client):

--- a/tests/transformers/test_narrative_transformer.py
+++ b/tests/transformers/test_narrative_transformer.py
@@ -3,42 +3,67 @@ from pyreal.explanation_types import FeatureContributionExplanation
 import pandas as pd
 import yaml
 from pyreal.explainers import LocalFeatureContribution
+from pyreal import RealApp
 
 
-def test_transform_feature_contribution():
-    with open("../keys.yml", "r") as file:
-        config = yaml.safe_load(file)
-        openai_api_key = config["openai_api_key"]
-
+def test_transform_feature_contribution(mock_openai_client):
     contributions = pd.DataFrame(
         [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]], columns=["A", "B", "C"]
     )
     values = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["A", "B", "C"])
     explanation = FeatureContributionExplanation(contributions, values)
-    transformer = NarrativeTransformer(openai_api_key=openai_api_key)
-    transformed_explanation = transformer.transform_explanation(explanation)
-    print(transformed_explanation.get())
+    transformer = NarrativeTransformer(openai_client=mock_openai_client["client"])
+    transformed_explanation = transformer.transform_explanation(explanation).get()
+    assert len(transformed_explanation) == contributions.shape[0]
+    for response in transformed_explanation:
+        assert response == mock_openai_client["response"]
 
 
-def test_transform_feature_contribution_full_workflow(regression_one_hot):
-    with open("../keys.yml", "r") as file:
-        config = yaml.safe_load(file)
-        openai_api_key = config["openai_api_key"]
-
+def test_transform_feature_contribution_full_workflow(regression_one_hot, mock_openai_client):
     model = regression_one_hot
     x = model["x"]
     lfc = LocalFeatureContribution(
         model=model["model"],
         e_algorithm="shap",
         transformers=[model["transformers"]]
-        + [NarrativeTransformer(openai_api_key=openai_api_key)],
+        + [NarrativeTransformer(openai_client=mock_openai_client["client"])],
     )
     lfc.fit(x)
 
     x_one_dim = pd.DataFrame([[2, 10, 10]], columns=["A", "B", "C"])
     x_multi_dim = pd.DataFrame([[4, 1, 1], [6, 2, 3]], columns=["A", "B", "C"])
     contributions = lfc.produce(x_one_dim).get()
-    print(contributions)
+    assert len(contributions) == 1
+    assert contributions[0] == mock_openai_client["response"]
 
     contributions = lfc.produce(x_multi_dim).get()
-    print(contributions)
+    assert len(contributions) == 2
+    assert contributions[0] == mock_openai_client["response"]
+    assert contributions[1] == mock_openai_client["response"]
+
+
+def test_transform_feature_contribution_realapp(regression_one_hot, mock_openai_client):
+    real_app = RealApp(
+        regression_one_hot["model"],
+        regression_one_hot["x"],
+        transformers=[regression_one_hot["transformers"]]
+        + [
+            NarrativeTransformer(
+                interpret=True, model=False, openai_client=mock_openai_client["client"]
+            )
+        ],
+        id_column="ID",
+    )
+
+    features = ["A", "B", "C"]
+    x_one_dim = pd.Series([4, 1, 1, "ab"], index=features + ["ID"])
+    explanation = real_app.produce_feature_contributions(x_one_dim)
+    assert len(explanation) == 1
+    assert explanation[0] == mock_openai_client["response"]
+
+    x_multi_dim = pd.DataFrame([[4, 1, 1, "a"], [6, 2, 3, "b"]], columns=features + ["ID"])
+
+    explanation = real_app.produce_feature_contributions(x_multi_dim)
+    assert len(explanation) == 2
+    assert explanation["a"] == mock_openai_client["response"]
+    assert explanation["b"] == mock_openai_client["response"]

--- a/tests/transformers/test_scale.py
+++ b/tests/transformers/test_scale.py
@@ -114,7 +114,3 @@ def test_inverse_transform_standardscale(scale_data):
 
     for i in range(len(sk)):
         assert all([sk[i][j] == std.values[i][j] for j in range(len(sk[i]))])
-
-
-if __name__ == "__main__":
-    print()


### PR DESCRIPTION
Adding a transformer that takes explanations of different types and transforms them into narrative (natural-language) formats, effectively doing the same thing as the existing produce_narrative functions. I am keeping the original produce_narrative functions (though they now use a NarrativeTransformer under-the-hood) as that workflow may be more natural for some people.

For now, NarrativeTransformer only handles feature contribution explanations; will extend with more options soon.